### PR TITLE
feat(auth): implement auto-login after signup and global 401 logout

### DIFF
--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -10,7 +10,29 @@ import { API_CONFIG } from '../constants/config';
 
 const apiUrl = import.meta.env.VITE_API_URL || API_CONFIG.DEFAULT_URL;
 
-// Create client with authentication headers
+/**
+ * Custom fetch wrapper that handles 401 unauthorized responses
+ * by logging out the user and redirecting to signin
+ */
+const fetchWithAuth: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init);
+
+  // Handle 401 Unauthorized - auto logout
+  if (response.status === 401) {
+    // Clear authentication data
+    localStorage.removeItem('auth_token');
+    localStorage.removeItem('auth_user');
+
+    // Redirect to signin page
+    if (typeof window !== 'undefined' && window.location.pathname !== '/auth/signin') {
+      window.location.href = '/auth/signin';
+    }
+  }
+
+  return response;
+};
+
+// Create client with authentication headers and custom fetch
 export const client = hc<AppType>(apiUrl, {
   headers: () => {
     const token = localStorage.getItem('auth_token');
@@ -18,6 +40,7 @@ export const client = hc<AppType>(apiUrl, {
       ? { Authorization: `Bearer ${token}` }
       : ({} as Record<string, string>);
   },
+  fetch: fetchWithAuth,
 });
 
 export type Client = typeof client;

--- a/packages/frontend/src/stores/auth.ts
+++ b/packages/frontend/src/stores/auth.ts
@@ -70,6 +70,12 @@ export const useAuthStore = defineStore("auth", () => {
 
       // HTTP semantics: success response is {token} directly
       const data = await response.json();
+      token.value = data.token;
+
+      if (typeof window !== "undefined") {
+        localStorage.setItem("auth_token", token.value);
+      }
+
       return { success: true, data };
     } catch (error) {
       return { success: false, error: (error as Error).message };

--- a/packages/frontend/src/views/auth/SignUpView.vue
+++ b/packages/frontend/src/views/auth/SignUpView.vue
@@ -163,8 +163,8 @@ async function handleSignup() {
     });
 
     if (result.success) {
-      // Redirect to signin with success message
-      await router.push('/auth/signin?signup=success');
+      // Auto-login successful - redirect to home
+      await router.push('/');
     } else {
       errorMessage.value = result.error || t('auth.signup.signupError');
     }


### PR DESCRIPTION
- Auto-login: Store JWT token immediately after successful signup and redirect user to home page instead of signin page
- Global 401 handling: Add fetch interceptor to automatically logout and redirect to signin when any API request returns 401 Unauthorized
- Update SignUpView to redirect to home after successful registration

Changes:
- packages/frontend/src/stores/auth.ts: Store token in signup function
- packages/frontend/src/views/auth/SignUpView.vue: Change redirect to home
- packages/frontend/src/api/client.ts: Add fetchWithAuth wrapper for 401 handling