### PR TITLE
chore(release): align Python runtime for v1.3.0

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -10,6 +10,6 @@ channel = "win-x64-stable"
 runtime = "win10.0.17763-x64"
 
 [toolchain]
-python = "3.14.6"
+python = "3.14.2"
 pdm = "2.26.6"
 velopack = "1.2.0"

--- a/scripts/verify_release_identity.py
+++ b/scripts/verify_release_identity.py
@@ -44,17 +44,24 @@ def _git(root: Path, *args: str) -> str:
 
 
 def _release_configuration(root: Path) -> tuple[str, int]:
-    version = str(
-        tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))[
-            "project"
-        ]["version"]
-    )
+    project = tomllib.loads(
+        (root / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]
+    version = str(project["version"])
     release = tomllib.loads((root / "release.toml").read_text(encoding="utf-8"))
     protocol_version = release.get("release", {}).get("protocol_version")
     if protocol_version != RELEASE_PROTOCOL_VERSION:
         raise RuntimeError(
             "Release protocol is unsupported: "
             f"expected {RELEASE_PROTOCOL_VERSION}, found {protocol_version!r}."
+        )
+    release_python = release.get("toolchain", {}).get("python")
+    project_python = project.get("requires-python")
+    if project_python != f"=={release_python}":
+        raise RuntimeError(
+            "Release Python toolchain must exactly match project requires-python: "
+            f"release.toml declares {release_python!r}, "
+            f"pyproject.toml declares {project_python!r}."
         )
     return version, protocol_version
 

--- a/tasks/release-v1.3.0.md
+++ b/tasks/release-v1.3.0.md
@@ -50,6 +50,10 @@ promotion and tag-triggered release path as its first production rehearsal.
   `release.toml` still recorded `3.14.6`; publishing from that state would make
   the immutable release manifest false.
 - `v1.3.0` remains unused locally and remotely, and no release workflow has run.
+- PR #112's first Native CI attempt exposed three release-identity behavior
+  fixtures that omitted the newly required Python fields. The validator remained
+  fail-closed; the fixtures now share one complete configuration writer, and the
+  full 144-test `platform-release` shard passes locally.
 - GitHub branch/tag rules and the `native-release` Environment still require the
   separately verified rollout described by the CI/CD task packet.
 

--- a/tasks/release-v1.3.0.md
+++ b/tasks/release-v1.3.0.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Release preparation is active. The first stopping point is a successful Native CI
-run on the `develop -> main` promotion PR. No `v1.3.0` tag exists and no release
-workflow or public publication is authorized before the user resumes.
+Release execution is active. Promotion PR #111 passed Native CI and was merged,
+but release preflight found a Python toolchain identity drift that must be promoted
+before the immutable `v1.3.0` tag is created.
 
 ## Objective
 
@@ -19,10 +19,10 @@ promotion and tag-triggered release path as its first production rehearsal.
   without rebasing or force-pushing.
 - Promote only through the same-repository `develop -> main` PR and require its
   stable `Native CI Gate`.
-- Stop after the promotion CI succeeds. Do not merge the PR or create/push
-  `v1.3.0` in this slice.
-- After resumption, tag only the completed promotion result on `main`; run the
+- Tag only the completed promotion result on `main`; run the
   mandatory local release-identity preflight before pushing the immutable tag.
+- Keep `pyproject.toml`, `release.toml`, CI, and release workflows on the same
+  exact Python runtime; release identity must reject configuration drift.
 - Release secrets remain confined to the tag-bound `native-release` Environment.
 - Preserve the unrelated uncommitted files in the primary develop worktree.
 
@@ -34,20 +34,27 @@ promotion and tag-triggered release path as its first production rehearsal.
   `main` base.
 - All four Python 3.14.2 semantic shards and the stable `Native CI Gate` pass on
   the final promotion head.
+- Local release identity accepts the exact `v1.3.0` tag, main first-parent
+  membership, and promotion PR before the tag is pushed.
+- The tag-bound Native Release workflow succeeds and publishes the canonical
+  v1.3.0 feed and release evidence.
 - The CI timing report records controlled, queue, and calendar durations; this
   first run is evidence but does not by itself satisfy the five-run acceptance
   sample.
 
 ## Current Truth
 
-- `origin/codex/cicd-simplification` was fast-forwarded into `origin/develop`.
-- Local `develop` merge-pulled that remote state while preserving product commit
-  `931450f`; the resulting source declares version `1.3.0`.
-- `v1.3.0` is unused remotely and no existing `develop -> main` PR is open.
+- Promotion PR #111 merged `develop` into `main` as `6fcbb001`, after all four
+  Python 3.14.2 semantic shards and `Native CI Gate` succeeded.
+- The promoted source declares project/runtime Python `3.14.2`, but
+  `release.toml` still recorded `3.14.6`; publishing from that state would make
+  the immutable release manifest false.
+- `v1.3.0` remains unused locally and remotely, and no release workflow has run.
 - GitHub branch/tag rules and the `native-release` Environment still require the
   separately verified rollout described by the CI/CD task packet.
 
 ## Next Step
 
-Commit and push the v1.3.0 release preparation on `develop`, open the promotion PR,
-wait for the final Native CI run, record its result, and stop before merge or tag.
+Promote the exact Python toolchain correction through `develop -> main`, then tag
+that completed promotion result, run local release-identity preflight, push the
+tag, and monitor Native Release through canonical publication.

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -21,6 +21,26 @@ def _load_script(name: str):
 release_identity = _load_script("verify_release_identity")
 
 
+def _write_release_configuration(
+    root: Path,
+    *,
+    version: str = "1.2.0",
+    python: str = "3.14.2",
+    protocol_version: int = 1,
+) -> None:
+    (root / "pyproject.toml").write_text(
+        f'[project]\nversion = "{version}"\nrequires-python = "=={python}"\n',
+        encoding="utf-8",
+    )
+    (root / "release.toml").write_text(
+        "[release]\n"
+        f"protocol_version = {protocol_version}\n"
+        "[toolchain]\n"
+        f'python = "{python}"\n',
+        encoding="utf-8",
+    )
+
+
 def _promotion_record(
     commit: str,
     *,
@@ -68,14 +88,7 @@ def test_verify_accepts_historical_first_parent_promotion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     commit = "a" * 40
-    (tmp_path / "pyproject.toml").write_text(
-        '[project]\nversion = "1.2.0"\n',
-        encoding="utf-8",
-    )
-    (tmp_path / "release.toml").write_text(
-        "[release]\nprotocol_version = 1\n",
-        encoding="utf-8",
-    )
+    _write_release_configuration(tmp_path)
 
     def git(_root: Path, *args: str) -> str:
         if args == ("rev-parse", "HEAD"):
@@ -111,14 +124,7 @@ def test_verify_rejects_side_branch_ancestor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     commit = "a" * 40
-    (tmp_path / "pyproject.toml").write_text(
-        '[project]\nversion = "1.2.0"\n',
-        encoding="utf-8",
-    )
-    (tmp_path / "release.toml").write_text(
-        "[release]\nprotocol_version = 1\n",
-        encoding="utf-8",
-    )
+    _write_release_configuration(tmp_path)
 
     def git(_root: Path, *args: str) -> str:
         if args == ("rev-parse", "HEAD"):
@@ -145,14 +151,7 @@ def test_release_protocol_and_tag_must_match_project_version(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     commit = "a" * 40
-    (tmp_path / "pyproject.toml").write_text(
-        '[project]\nversion = "1.2.0"\n',
-        encoding="utf-8",
-    )
-    (tmp_path / "release.toml").write_text(
-        "[release]\nprotocol_version = 1\n",
-        encoding="utf-8",
-    )
+    _write_release_configuration(tmp_path)
     monkeypatch.setattr(
         release_identity,
         "_git",
@@ -164,9 +163,6 @@ def test_release_protocol_and_tag_must_match_project_version(
     with pytest.raises(RuntimeError, match="exactly tag"):
         release_identity.verify(tmp_path, require_tag=True)
 
-    (tmp_path / "release.toml").write_text(
-        "[release]\nprotocol_version = 2\n",
-        encoding="utf-8",
-    )
+    _write_release_configuration(tmp_path, protocol_version=2)
     with pytest.raises(RuntimeError, match="protocol is unsupported"):
         release_identity.verify(tmp_path, require_tag=False)


### PR DESCRIPTION
## Why
Release preflight found that the promoted v1.3.0 source used Python 3.14.2 everywhere except the release manifest authority, which still recorded 3.14.6.

## Change
- align `release.toml` with the PDM-managed Python 3.14.2 runtime
- make the existing release-identity preflight reject future project/release Python drift
- update the active v1.3.0 release packet

## Verification
- `pdm run check`
- `pdm lock --check`
- `pdm run release-identity`
- `git diff --check`