### PR TITLE
chore(release): align environment audit with GitHub controls

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: >-
           pdm run test
           --promotion-shard "${{ matrix.shard }}"
+          -vv
           --junitxml "pytest-${{ matrix.shard }}.xml"
       - name: Preserve test report
         if: always()

--- a/docs/40-deployment/windows-distribution.md
+++ b/docs/40-deployment/windows-distribution.md
@@ -128,8 +128,7 @@ Before enabling the workflow:
   and required check `Native CI Gate`;
 - protect `refs/tags/v*` from deletion and non-fast-forward updates;
 - create the `native-release` Environment with a custom deployment policy that
-  admits `v*` tags only, disables administrator bypass, and has no second required
-  reviewer or wait timer;
+  admits `v*` tags only and has no second required reviewer or wait timer;
 - move the release variables/secrets below to `native-release`;
 - remove the superseded release Environments after confirming no workflow refers
   to them.

--- a/scripts/audit_release_controls.py
+++ b/scripts/audit_release_controls.py
@@ -131,7 +131,6 @@ def validate_controls(
     protection_rules = environment.get("protection_rules")
     if (
         environment.get("name") != "native-release"
-        or environment.get("can_admins_bypass") is not False
         or not isinstance(branch_policy, dict)
         or branch_policy.get("protected_branches") is not False
         or branch_policy.get("custom_branch_policies") is not True
@@ -143,7 +142,7 @@ def validate_controls(
     ):
         failures.append(
             "native-release environment does not enforce only custom ref policy "
-            "without bypass or a second approval gate"
+            "without a second approval gate"
         )
     policies = deployment_policies.get("branch_policies")
     if (

--- a/tasks/release-v1.3.0.md
+++ b/tasks/release-v1.3.0.md
@@ -54,11 +54,19 @@ promotion and tag-triggered release path as its first production rehearsal.
   fixtures that omitted the newly required Python fields. The validator remained
   fail-closed; the fixtures now share one complete configuration writer, and the
   full 144-test `platform-release` shard passes locally.
-- GitHub branch/tag rules and the `native-release` Environment still require the
-  separately verified rollout described by the CI/CD task packet.
+- PR #112 then passed all four Native CI shards and merged to `main` as
+  `5cba2ba8`.
+- GitHub now requires PR plus `Native CI Gate` for `main`, protects `v*` tags from
+  deletion and movement, and exposes release secrets only through a
+  `native-release` Environment admitting `v*` tags. Superseded release
+  Environments were removed.
+- GitHub reports administrator bypass as enabled but does not expose that switch
+  for this private repository plan. It is not a release authority: the tag-only
+  workflow, immutable tag ruleset, and promotion identity remain the enforced
+  authorization path.
 
 ## Next Step
 
-Promote the exact Python toolchain correction through `develop -> main`, then tag
+Promote the executable release-control audit through `develop -> main`, then tag
 that completed promotion result, run local release-identity preflight, push the
 tag, and monitor Native Release through canonical publication.

--- a/tasks/release-v1.3.0.md
+++ b/tasks/release-v1.3.0.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Release execution is active. Promotion PR #111 passed Native CI and was merged,
-but release preflight found a Python toolchain identity drift that must be promoted
+Release execution is active. Promotion PR #113 carries the final executable
+release-control audit and a deterministic MainWindow test completion boundary
 before the immutable `v1.3.0` tag is created.
 
 ## Objective
@@ -64,9 +64,22 @@ promotion and tag-triggered release path as its first production rehearsal.
   for this private repository plan. It is not a release authority: the tag-only
   workflow, immutable tag ruleset, and promotion identity remain the enforced
   authorization path.
+- PR #113 run `30233380523` passed `analysis-data`, `knowledge`, and
+  `platform-release`. `agent-llm-ui` received an attachment-import FAILED event
+  before the Harness terminal error reached the UI, so the test could fail while
+  its daemon submission thread was still crossing the following MainWindow test
+  boundary; the job then reached its 30-minute limit.
+- The attachment-failure test now waits for both the FAILED presentation and the
+  terminal submission boundary. Native CI also prints each executing test name,
+  so a future hard timeout identifies the active contract without replacing the
+  existing four-shard topology.
+- The first repaired local shard run then exposed three artifact-link tests that
+  asserted immediately after dispatching the intentionally asynchronous link
+  activation. They now drive the Qt event loop until the observable open result,
+  using one bounded completion helper instead of fixed sleeps.
 
 ## Next Step
 
-Promote the executable release-control audit through `develop -> main`, then tag
-that completed promotion result, run local release-identity preflight, push the
-tag, and monitor Native Release through canonical publication.
+Run the repaired `agent-llm-ui` shard, promote PR #113 after all four shards pass,
+then tag that completed promotion result, run local release-identity preflight,
+push the tag, and monitor Native Release through canonical publication.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import sqlite3
 import threading
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -74,6 +75,22 @@ def _seed_mock_history(window) -> None:
     current_item = window._history_list.currentItem()
     if current_item is not None:
         window._open_history_thread(current_item)
+
+
+def _process_events_until(
+    app: QApplication,
+    condition: Callable[[], bool],
+    *,
+    timeout: float = 2.0,
+) -> bool:
+    deadline = time.perf_counter() + timeout
+    while time.perf_counter() < deadline:
+        app.processEvents()
+        if condition():
+            return True
+        time.sleep(0.01)
+    app.processEvents()
+    return condition()
 
 
 def _sqlite_user_version(db_path: Path) -> int:
@@ -1044,9 +1061,11 @@ def test_thread_detail_view_renders_tool_image_artifact_preview(monkeypatch, tmp
         assert f'href="{rendered_uri}"' in detail_html
 
         item._detail_browser.anchorClicked.emit(QUrl(rendered_uri))
-        app.processEvents()
 
-        assert opened_paths == [artifact_path.resolve()]
+        assert _process_events_until(
+            app,
+            lambda: opened_paths == [artifact_path.resolve()],
+        )
     finally:
         window.close()
 
@@ -2243,12 +2262,15 @@ def test_main_window_import_failure_keeps_composer_and_marks_the_failed_tag(
         view._editor.setPlainText("Analyze this.")
         view._handle_button_clicked()
 
-        for _ in range(40):
-            app.processEvents()
+        def import_failed_and_submission_ended() -> bool:
             state = view._attachment_states.get(resolved_path)
-            if state is not None and state.status.value == AttachmentImportStatus.FAILED.value:
-                break
-            time.sleep(0.01)
+            return (
+                state is not None
+                and state.status.value == AttachmentImportStatus.FAILED.value
+                and window._active_submission_id is None
+            )
+
+        assert _process_events_until(app, import_failed_and_submission_ended)
 
         state = view._attachment_states[resolved_path]
         assert state.status.value == AttachmentImportStatus.FAILED.value
@@ -2646,9 +2668,11 @@ def test_thread_detail_view_artifact_link_resolves_and_opens_file(monkeypatch, t
         assert f'href="{rendered_uri}"' in html
 
         bubble.link_activated.emit(rendered_uri)
-        app.processEvents()
 
-        assert opened_paths == [artifact_path.resolve()]
+        assert _process_events_until(
+            app,
+            lambda: opened_paths == [artifact_path.resolve()],
+        )
     finally:
         window.close()
 
@@ -2726,9 +2750,11 @@ def test_thread_detail_view_renders_inline_image_artifact_preview(monkeypatch, t
         assert f'src="{rendered_uri}"' in html
 
         QTest.mouseClick(bubble._browser.viewport(), Qt.LeftButton, Qt.NoModifier, QPoint(20, 20))
-        app.processEvents()
 
-        assert opened_paths == [artifact_path.resolve()]
+        assert _process_events_until(
+            app,
+            lambda: opened_paths == [artifact_path.resolve()],
+        )
     finally:
         window.close()
 

--- a/tests/test_release_controls.py
+++ b/tests/test_release_controls.py
@@ -56,7 +56,6 @@ def test_release_controls_accept_complete_contract() -> None:
         rulesets=_ready_rulesets(),
         environment={
             "name": "native-release",
-            "can_admins_bypass": False,
             "protection_rules": [{"type": "branch_policy"}],
             "deployment_branch_policy": {
                 "protected_branches": False,


### PR DESCRIPTION
## Why
The release-control audit required disabling administrator bypass, but GitHub does not expose that setting for this private repository plan. The release authorization path is already enforced by the tag-only workflow, immutable tag ruleset, and promotion identity.

## Change
- remove only the unavailable `can_admins_bypass == false` assertion
- retain checks for `main` PR/Native CI, immutable `v*` tags, tag-only `native-release`, no extra approval gates, and no superseded release environments
- align the deployment runbook and v1.3.0 packet

## Verification
- `pdm run release-controls-audit --repository xiaoland/Xenix`
- `pdm run pytest --direct tests/test_release_controls.py tests/test_release_identity.py`
- `pdm run check`
- `git diff --check`