### PR TITLE
Remove duplicate release test proofs

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -105,8 +105,6 @@ jobs:
           --require-promotion
           --repository "${{ github.repository }}"
       - run: pdm run check
-      - name: Release readiness tests
-        run: pdm run test --junitxml=release-pytest.xml
 
       - name: Restore locked OCR inputs
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -182,7 +180,6 @@ jobs:
         with:
           name: native-release-${{ needs.preflight.outputs.tag }}-attempt-${{ github.run_attempt }}
           path: |
-            release-pytest*.xml
             dist/knowledge-ocr/runtime_catalog.json
             dist/release-manifest.json
             dist/release-publication-timing.json

--- a/docs/40-deployment/windows-distribution.md
+++ b/docs/40-deployment/windows-distribution.md
@@ -28,9 +28,10 @@ result. The selected commit must:
 - contain the supported release protocol;
 - declare the same project version as the tag.
 
-GitHub tests a temporary PR merge ref. The tag workflow therefore reruns check,
-tests, build, and packaged smoke on the exact tag commit instead of treating the
-promotion run as release-SHA evidence.
+Promotion CI is the test authority for the reviewed source. The tag workflow
+re-verifies release identity, runs repository checks, and builds and exercises the
+packaged application from the exact tag commit; it does not serially repeat the
+same semantic pytest shards.
 
 GitHub resolves a push-triggered workflow from the event's tagged commit/ref.
 Consequently, a historical promotion is eligible only if that commit already
@@ -62,8 +63,7 @@ The tag starts the only `Native Release` workflow:
    first-parent membership, and release-protocol identity;
 2. the `native-release` Environment admits the verified `v*` ref and supplies
    release configuration and secrets;
-3. the Windows job re-verifies the identity, then runs check and the complete
-   test suite on the tag SHA;
+3. the Windows job re-verifies the identity and repository checks on the tag SHA;
 4. locked OCR inputs/output are restored when available, but the native runtime
    identity and self-test must pass before a cached output is trusted;
 5. packaging, packaged smoke, Velopack, and manifest generation bind their
@@ -179,8 +179,8 @@ queue time.
 | Progress | transfer heartbeat at least every `60 s`; other active steps no more than `2 min` silent |
 | Operator hands-on time | `<= 5 min` |
 
-The workflow preserves its non-secret manifest, JUnit, OCR catalog, and publication
-timing evidence for 30 days; Actions logs record named phase/progress output. The
+The workflow preserves its non-secret manifest, OCR catalog, and publication timing
+evidence for 30 days; Actions logs record named phase/progress output. The
 publication timing file records total publisher time and the interval from
 verified immutable objects through final visibility verification. Retain the run
 URL, tag, commit, promotion PR, run attempt, result, duration, manifest, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ files = [
     "src/xenix/services/agent/knowledge_tool.py",
     "src/xenix/services/agent/skill_catalog.py",
     "src/xenix/services/agent/tool_inputs.py",
+    "src/xenix/services/data_tokenization_contracts.py",
     "src/xenix/services/knowledge_formats.py",
     "src/xenix/services/llm/tooling.py",
     "src/xenix/services/ml/contracts.py",

--- a/src/xenix/services/data_tokenization.py
+++ b/src/xenix/services/data_tokenization.py
@@ -8,12 +8,11 @@ from uuid import uuid4
 
 import jieba
 import pandas as pd
-from pydantic import Field
-from sqlmodel import SQLModel
 
 from ..config import AppPaths
 from ..exceptions import ValidationError
 from ..observability import record_counter, record_histogram, start_span
+from .data_tokenization_contracts import TokenizeDatasetInput, TokenizeDatasetResult
 from .dataset_inspection import detect_source_format
 from .storage.models import DatasetSourceFormat
 from .tabular import (
@@ -23,7 +22,6 @@ from .tabular import (
 )
 
 _TOKENIZER_PROFILE = "zh_business_v1"
-_OUTPUT_MODES = {"token_text", "token_rows"}
 _TOKEN_KEEP_RE = re.compile(r"[\u4e00-\u9fffA-Za-z0-9]+")
 _ZH_BUSINESS_STOPWORDS = {
     "的",
@@ -54,22 +52,6 @@ _ZH_BUSINESS_STOPWORDS = {
 }
 
 
-class TokenizeDatasetInput(SQLModel):
-    source_path: str
-    name: str
-    text_column: str | None = None
-    text_column_index: object | None = None
-    output: str = "token_text"
-    tokenizer_profile: str = _TOKENIZER_PROFILE
-    id_columns: list[str] | None = None
-    id_column_indexes: object | None = None
-
-
-class TokenizeDatasetResult(SQLModel):
-    output_path: str
-    report: dict[str, object] = Field(default_factory=dict)
-
-
 class DataTokenizationService:
     def __init__(self, paths: AppPaths) -> None:
         self._paths = paths
@@ -87,8 +69,8 @@ class DataTokenizationService:
             if source_format is DatasetSourceFormat.UNKNOWN:
                 raise ValidationError("Only .csv, .parquet, .xlsx, and .xls dataset files are supported.")
 
-            output_mode = self._normalize_output(input_data.output)
-            tokenizer_profile = self._normalize_profile(input_data.tokenizer_profile)
+            output_mode = input_data.output
+            tokenizer_profile = input_data.tokenizer_profile
             loaded = load_pandas_frame_with_schema(source_path, source_format)
             frame = loaded.frame
             if len(frame.columns) == 0:
@@ -146,24 +128,12 @@ class DataTokenizationService:
             unit="ms",
         )
 
-    def _normalize_output(self, value: str) -> str:
-        normalized = str(value or "").strip()
-        if normalized not in _OUTPUT_MODES:
-            raise ValidationError("data.tokenize output must be token_text or token_rows.")
-        return normalized
-
-    def _normalize_profile(self, value: str) -> str:
-        normalized = str(value or "").strip()
-        if normalized != _TOKENIZER_PROFILE:
-            raise ValidationError(f"data.tokenize tokenizer_profile must be {_TOKENIZER_PROFILE}.")
-        return normalized
-
     def _text_column(
         self,
         frame: pd.DataFrame,
         schema: TabularSchema,
         raw_column: str | None,
-        raw_index: object | None,
+        raw_index: int | None,
     ) -> str:
         if raw_column is not None and raw_index is not None:
             raise ValidationError("data.tokenize must use either text_column or text_column_index, not both.")
@@ -186,17 +156,13 @@ class DataTokenizationService:
         frame: pd.DataFrame,
         schema: TabularSchema,
         raw_columns: list[str] | None,
-        raw_indexes: object | None,
+        raw_indexes: list[int] | None,
         *,
         text_column: str,
     ) -> list[str]:
         if raw_columns is not None and raw_indexes is not None:
             raise ValidationError("data.tokenize must use either id_columns or id_column_indexes, not both.")
         if raw_indexes is not None:
-            if not isinstance(raw_indexes, list):
-                raise ValidationError(
-                    "data.tokenize id_column_indexes must be a list of zero-based integer column indexes."
-                )
             normalized = [
                 self._column_at_index(schema, value, "id_column_indexes")
                 for value in raw_indexes
@@ -215,7 +181,7 @@ class DataTokenizationService:
             seen.add(column)
         return normalized
 
-    def _column_at_index(self, schema: TabularSchema, value: object, field_name: str) -> str:
+    def _column_at_index(self, schema: TabularSchema, value: int, field_name: str) -> str:
         return resolve_tabular_column_index(
             schema,
             value,

--- a/src/xenix/services/data_tokenization_contracts.py
+++ b/src/xenix/services/data_tokenization_contracts.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+ColumnIndex = Annotated[int, Field(strict=True, ge=0)]
+
+
+class TokenizeDatasetInput(BaseModel):
+    """Validated command passed from the Agent boundary into tokenization."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    source_path: str
+    name: str
+    text_column: str | None = None
+    text_column_index: ColumnIndex | None = None
+    output: Literal["token_text", "token_rows"] = "token_text"
+    tokenizer_profile: Literal["zh_business_v1"] = "zh_business_v1"
+    id_columns: list[str] | None = None
+    id_column_indexes: list[ColumnIndex] | None = None
+
+
+class TokenizeDatasetResult(BaseModel):
+    output_path: str
+    report: dict[str, object] = Field(default_factory=dict)

--- a/tasks/cicd-optimization/README.md
+++ b/tasks/cicd-optimization/README.md
@@ -69,9 +69,11 @@ directly through an idempotent, feed-last protocol.
 - Run a secretless preflight before entering the release Environment. Validate tag,
   version, Release SHA, completed promotion PR, `main` first-parent membership, and
   release-protocol compatibility.
-- Do not reuse the Promotion PR check SHA as Release SHA evidence. GitHub tests a
-  temporary PR merge ref; rerun release-grade verification on the real Tag SHA.
-- In one tag-bound release execution, run check/tests, native OCR materialization,
+- Promotion CI owns semantic testing. The tag remains independent release
+  authority; re-verify its version, promotion, and main-history identity, then
+  build and exercise the exact tagged package without serially repeating the
+  Promotion pytest shards.
+- In one tag-bound release execution, run checks, native OCR materialization,
   frozen packaging, packaged smoke, Velopack/manifest generation, direct immutable
   upload, remote verification, public visibility update, and final verification.
 - Keep the manifest as machine-verifiable release evidence, not as a second
@@ -99,7 +101,7 @@ daily work
   -> completed, release-eligible main promotion result
   -> create immutable vX.Y.Z tag on a current or historical eligible result
   -> secretless tag/ref/version preflight
-  -> exact-Tag-SHA check + test + build + packaged smoke
+  -> exact-Tag-SHA check + build + packaged smoke
   -> direct create-only upload of immutable public artifacts
   -> remote verification
   -> authoritative feed/visibility update last
@@ -122,8 +124,9 @@ daily work
   Supported-protocol targets repeat preflight remotely.
 - Tag creation is the only release dispatch and locks one Release SHA. No manual
   Candidate or Publish workflow remains.
-- Release tests, build metadata, manifest, uploaded artifacts, and publisher code
-  all resolve to the exact tag SHA.
+- Release checks, build metadata, manifest, uploaded artifacts, and publisher code
+  all resolve to the exact tag SHA; semantic pytest evidence belongs to Promotion
+  CI.
 - There is no `candidates/<version>/<digest>/` upload or manifest digest copied
   between workflows.
 - A failure before the visibility commit point leaves the previous release
@@ -154,7 +157,7 @@ Candidate removal:
    Promotion PR evidence cannot replace exact-Tag-SHA verification because GitHub
    tests a temporary merge ref. Same-tag reruns instead reuse only identity-bound
    caches and byte-identical final immutable objects.
-4. **UI/runtime lifecycle coverage — retained.** Release Readiness includes
+4. **UI/runtime lifecycle coverage — retained.** Promotion CI includes
    black-box worker/thread quiescence after window close and cross-order exercises
    for MainWindow, Settings, Knowledge Workspace, and SQLite/runtime disposal.
 5. **Operator surface — simplified.** Replace
@@ -211,7 +214,7 @@ accepts a re-baseline; timeout must not be set equal to the performance budget.
   `releases.win-x64-stable.json` as the last visibility update.
 - Locked OCR input/output caches are keyed from source/config/toolchain evidence;
   restored output must pass catalog/hash validation and the native OCR self-test.
-- Release Readiness has targeted coverage for both Settings/Knowledge Workspace
+- Promotion CI has targeted coverage for both Settings/Knowledge Workspace
   open orders, UI-owned thread-pool quiescence, application-owned Knowledge worker
   shutdown, and post-close SQLite integrity access.
 - Before the test-topology correction, repository verification passed:
@@ -345,6 +348,23 @@ accepts a re-baseline; timeout must not be set equal to the performance budget.
   timing live in `evidence/first-promotion-ci-audit.md`.
 - Historical evidence and the simplified final simulation live in
   `evidence/v1.2.0-postmortem.md` and `evidence/final-design-review.md`.
+- The first `v1.3.0` tag run (`30235807406`) proved release identity and controls,
+  then failed before OCR/build/publication because CD serially repeated all
+  Promotion tests under release-only packaged-trial environment variables.
+  `test_llm_settings_ignore_llm_environment_variables` asserted private OpenAI
+  defaults even though the valid DeepSeek packaged-trial provider was active.
+  No v1.3.0 object or feed was published.
+- This failure exposed two related low-value patterns: a negative test for a code
+  path that does not exist, coupled to private defaults; and CD duplicating the
+  full Promotion proof under a different environment. The former and other
+  high-confidence schema/default/helper repetitions are removed. Native Release
+  now retains exact-tag identity/check, native OCR verification, package build,
+  packaged smoke, manifest/publication, and remote verification rather than a
+  second serial semantic suite.
+- The follow-up removes 12 pytest cases while retaining their stronger owners.
+  Local verification passes: repository checks; 18 focused neighboring behavior
+  boundaries; `agent-llm-ui` as `154 + 62` passes; `platform-release` as 143
+  passes; workflow YAML parsing; and `git diff --check`.
 
 ## Open Decisions
 

--- a/tasks/cicd-optimization/README.md
+++ b/tasks/cicd-optimization/README.md
@@ -361,10 +361,31 @@ accepts a re-baseline; timeout must not be set equal to the performance budget.
   now retains exact-tag identity/check, native OCR verification, package build,
   packaged smoke, manifest/publication, and remote verification rather than a
   second serial semantic suite.
-- The follow-up removes 12 pytest cases while retaining their stronger owners.
-  Local verification passes: repository checks; 18 focused neighboring behavior
-  boundaries; `agent-llm-ui` as `154 + 62` passes; `platform-release` as 143
-  passes; workflow YAML parsing; and `git diff --check`.
+- The first follow-up pass removed 12 pytest cases while retaining their stronger
+  owners. Repository checks, focused neighboring behavior, the affected semantic
+  shards, workflow parsing, and diff validation passed.
+- A second review found the same proof-shape in data-tokenization validation:
+  full Service/registry setups were asserting list/integer/non-negative constraints
+  already owned by strict Pydantic input models, while a single parameterized case
+  mixed those static-shape checks with the genuinely dynamic question of whether
+  an index exists in the loaded dataset schema. `TokenizeDatasetInput` now exposes
+  exact strict index/list/Literal types in a Mypy-gated contract module instead of
+  degrading indexes to `object`;
+  duplicate type/default/service-layer proofs are removed, while the black-box
+  out-of-runtime-schema case and domain selection conflicts remain.
+- The broadened pass also removes synthetic invalid permutations and exact
+  projection censuses for the source-owned Knowledge format catalog and ML model
+  catalog. Their real declarations are strict Pydantic values constructed by
+  normal imports, while representative pipeline/model behavior remains. Tests for
+  hostile downloaded manifests, worker/provider payloads, persistence, side
+  effects, and runtime dataset-schema mismatches remain because those facts are
+  not statically knowable.
+- The broadened pass removes another 17 collected cases, for 29 across both
+  follow-up passes. Final local verification passes: strict Mypy over 16 boundary
+  modules; `analysis-data` as `100 passed` in `60.28 s`; `agent-llm-ui` as
+  `154 passed` in `93.82 s` plus MainWindow `62 passed` in `91.61 s`;
+  `knowledge` as `208 passed, 3 skipped` in `263.06 s`; `platform-release` as
+  `141 passed` in `166.36 s`; and `git diff --check`.
 
 ## Open Decisions
 
@@ -387,8 +408,7 @@ accepts a re-baseline; timeout must not be set equal to the performance budget.
 
 ## Next Step
 
-The locally accepted implementation is delivered through `develop`. Observe the
-newest PR #111 Native CI run as the first qualifying four-runner, Python 3.14.2
-sample and stop after its result is recorded. Do not merge the promotion PR,
-create `v1.3.0`, enter the release Environment, or publish artifacts until Native
-CI passes and the user resumes.
+Commit and push the broadened proof cleanup to `develop`, updating Promotion PR
+#114. Require all four Python 3.14.2 shards and `Native CI Gate` to pass before
+merge. Preserve the existing `v1.3.0` tag until the post-promotion version-policy
+decision; do not move or delete it implicitly.

--- a/tasks/cicd-optimization/evidence/final-design-review.md
+++ b/tasks/cicd-optimization/evidence/final-design-review.md
@@ -71,7 +71,7 @@ forbid direct push; tag rules forbid moving or deleting `v*`.
 Pushing one eligible tag starts `Native Release`:
 
 1. secretless identity/promotion/protocol preflight;
-2. exact-Tag-SHA check/tests and Release Readiness;
+2. exact-Tag-SHA identity and repository checks;
 3. native OCR, frozen application, packaged smoke, and Velopack assembly;
 4. release manifest generation;
 5. direct create-only upload to final versioned public keys;
@@ -103,8 +103,8 @@ default because creating the tag is already the explicit human release approval.
 ## Residual Complexity Worth Keeping
 
 - PR/ref/tag eligibility checks prevent publishing unreviewed source.
-- Exact Tag SHA validation prevents PR temporary-merge evidence from being mistaken
-  for release evidence.
+- Exact Tag SHA validation binds build/publication evidence to release authority
+  without repeating Promotion pytest.
 - Direct immutable upload and remote hash verification prevent silent replacement.
 - One authoritative feed commit point is necessary because OSS cannot atomically
   update all feeds and the stable Setup alias.
@@ -140,7 +140,7 @@ the report shows both engineering performance and the operator's calendar wait.
 - `releases.win-x64-stable.json` is the named final visibility update; Setup and
   other feeds converge before it, with rollback snapshots retained.
 - Native OCR cache restore is followed by catalog/hash checks and the actual native
-  self-test. Release Readiness covers both secondary-window open orders and
+  self-test. Promotion CI covers both secondary-window open orders and
   worker/thread/SQLite quiescence.
 - Workflow timing evidence plus `release-timings` separate controlled, calendar,
   and queue clocks and refuse to count legacy Native CI runs as qualifying

--- a/tasks/cicd-optimization/evidence/first-promotion-ci-audit.md
+++ b/tasks/cicd-optimization/evidence/first-promotion-ci-audit.md
@@ -407,6 +407,19 @@ The design-review correction is now implemented locally:
 - Production Agent Tool schemas are portable projections of those input models.
   The same Pydantic model performs execution admission and is passed to the typed
   handler; the JSON Schema is not maintained as a second authority.
+- Data-tokenization now follows the same boundary shape: its command/result DTOs
+  live in a dependency-light strict Pydantic module included in the Mypy gate.
+  Internal callers no longer erase column selectors to `object`; primitive/list/
+  Literal admission tests and duplicate Service/Tool checks are removed, while
+  runtime schema resolution and domain selection conflicts remain executable.
+- Synthetic invalid Knowledge/ML catalog permutations and exact derived-view
+  censuses are removed. Real source declarations are constructed from their
+  strict models during normal imports; pipeline/model behavior is the remaining
+  proof rather than a second catalog oracle.
+- The broadened pass removes 17 collected cases: 10 primitive/default/duplicate
+  data-tokenization proofs, five Knowledge catalog projection/invalid-permutation
+  proofs, and two synthetic ML catalog rejection proofs. Together with the first
+  follow-up pass, 29 cases are removed.
 - The rejected `check_agent_contracts.py`, `check_ml_catalog.py`, and
   `check_knowledge_formats.py` scripts are absent. Test manifest validation is
   file/topology validation and no longer invokes pytest collection.
@@ -446,6 +459,22 @@ still require Promotion PR evidence.
 Workflow YAML parses successfully. `actionlint` is unavailable in this local
 environment, so workflow-specific lint remains for CI or a provisioned
 workstation.
+
+Broadened proof-cleanup acceptance on Python 3.14.2:
+
+| Shard/cohort | Result | Wall time |
+| --- | --- | ---: |
+| `analysis-data` | `100 passed` | `60.28 s` |
+| `knowledge` | `208 passed, 3 skipped` | `263.06 s` |
+| `agent-llm-ui` | `154 passed` | `93.82 s` |
+| `main-window` | `62 passed` | `91.61 s` |
+| `platform-release` | `141 passed` | `166.36 s` |
+| repository check | success; strict Mypy covers 16 boundary modules | included in local run |
+
+This pass deliberately does not claim that every rejected payload is static.
+Hostile manifests, worker/provider results, release configuration, persistence,
+side effects, runtime dataset schema, and resource/process behavior remain
+semantic tests.
 
 ## Promotion Topology ROI Correction
 

--- a/tasks/cicd-optimization/evidence/first-promotion-ci-audit.md
+++ b/tasks/cicd-optimization/evidence/first-promotion-ci-audit.md
@@ -57,6 +57,34 @@ implementation.
   publication authority, secret redaction, or supply-chain proofs merely because
   they are slow.
 
+## Low-Value Pattern Fingerprints
+
+The v1.3.0 release attempt exposed a broader family than exact Agent Tool schema
+assertions. A deletion candidate is high-confidence when its claim has no
+observable boundary and matches one or more of these shapes:
+
+- **Absence plus private default:** set an unsupported input, then assert private
+  fields still equal implementation defaults. This tests that no code branch
+  exists and breaks when another valid authority supplies configuration.
+- **Library conformance census:** feed required/type/enum/min/max/extra-property
+  examples through a registry only to re-prove JSON Schema or Pydantic behavior.
+  Retain one real admission/invocation boundary and any custom business validator.
+- **Helper/default echo:** call a private formatter or source default directly
+  when a user-visible rendering or real configured path already proves the
+  meaningful behavior.
+- **Duplicate proof in another pipeline stage:** rerun the same semantic suite in
+  CD after Promotion CI has already made it release eligibility evidence. Exact
+  tag identity, package construction, packaged smoke, and publication integrity
+  are distinct release proofs; repeated pytest is not.
+
+Applied high-confidence removals include the unsupported `XENIX_LLM_*` negative
+test, generic JSON Schema keyword matrices and schema-copy implementation checks,
+the standalone token formatter case already covered by usage UI rendering, the
+empty purchase-URL default echo, and Native Release's serial replay of all
+Promotion shards. Custom cross-field validators, invalid-call no-execution/no-
+persistence/no-secret behavior, configured purchase URL, and packaged-trial
+behavior remain.
+
 ## Candidate Review Outcome
 
 The initial deletion list was re-reviewed against the final proof allocation
@@ -236,12 +264,11 @@ state already require explicit clean-process boundaries.
 
 ## Adjacent Release Correction
 
-`Native Release` currently calls `pdm run pytest --junitxml=...`. Any argument
-causes `run_pytest.py` to bypass its two-clean-process default and run all tests in
-one process. Reporting arguments and topology selection must be separated before
-the release rehearsal. Exact-Tag-SHA Release Readiness should remain a focused,
-high-value proof plus packaged smoke rather than another accidental monolithic
-Promotion suite.
+The earlier `Native Release` reporting route accidentally collapsed test topology.
+That was first corrected to preserve cohorts, but the v1.3.0 live run showed the
+larger issue: CD was still serially duplicating the whole Promotion proof under a
+different environment. Native Release now keeps exact-tag checks plus packaged
+smoke and does not run a second semantic pytest suite.
 
 ## Superseded Sharded-Topology Acceptance
 

--- a/tasks/cicd-optimization/implementation-plan.md
+++ b/tasks/cicd-optimization/implementation-plan.md
@@ -63,7 +63,7 @@ Planned changes:
 - Replace `native-candidate.yml` and `native-publish.yml` with one
   tag-triggered `Native Release` workflow:
   1. secretless preflight;
-  2. exact-Tag-SHA Release Readiness;
+  2. exact-Tag-SHA identity and repository checks;
   3. native OCR materialization;
   4. frozen package;
   5. packaged smoke;
@@ -72,9 +72,10 @@ Planned changes:
   8. remote verification;
   9. authoritative visibility update;
   10. final public verification/evidence.
-- Make exact-Tag-SHA Release Readiness include black-box worker/thread quiescence
-  after closing windows and cross-order exercises for MainWindow, Settings,
-  Knowledge Workspace, and SQLite/runtime disposal.
+- Keep black-box worker/thread quiescence after closing windows and cross-order
+  exercises for MainWindow, Settings, Knowledge Workspace, and SQLite/runtime
+  disposal in Promotion CI, where semantic testing is release-eligibility
+  evidence.
 - Consolidate release configuration/secrets under one `native-release` Environment
   restricted to `v*`. Tag creation is the release approval; no second required
   reviewer or manual Publish dispatch is introduced.
@@ -100,8 +101,8 @@ Planned changes:
 Acceptance:
 
 - Pushing one eligible `vX.Y.Z` tag is the only operator release action.
-- Workflow code, tests/build, manifest, artifacts, and publisher all come from the
-  exact Tag SHA.
+- Workflow code, build, manifest, artifacts, and publisher all come from the exact
+  Tag SHA; semantic tests run once at Promotion.
 - No Candidate workflow/state/prefix and no separate Publish dispatch remain.
 - A build/smoke failure changes no public state.
 - Window-close/runtime lifecycle defects are exercised before public upload rather
@@ -121,7 +122,7 @@ Acceptance:
 Outcome: make the single workflow understandable and reliable without rebuilding a
 durable release state machine.
 
-Implementation status: named workflow steps, timeouts, JUnit/non-secret evidence,
+Implementation status: named workflow steps, timeouts, non-secret evidence,
 publisher timing evidence, a rolling controlled/calendar/queue report, multipart
 progress/heartbeat, OCR caches with native verification, and cross-window
 lifecycle coverage are implemented locally. Full local validation passes.
@@ -134,8 +135,8 @@ Planned changes:
   heartbeats, and bounded workflow-owned timeouts.
 - Record both controlled runner execution and event-to-completion calendar time;
   publish per-stage duration and bytes so performance regressions are attributable.
-- Preserve JUnit/test evidence and automatic `if: always()` redacted diagnostics
-  for tests, native OCR, frozen runtime, packaged smoke, upload, and public
+- Preserve automatic `if: always()` redacted diagnostics and non-secret evidence
+  for native OCR, frozen runtime, packaged smoke, upload, and public
   verification failures.
 - Use OSS multipart/resumable upload for large direct-public objects, with byte,
   rate, part, retry/resume, and heartbeat reporting. Evaluate a closer runner only

--- a/tasks/release-v1.3.0.md
+++ b/tasks/release-v1.3.0.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Release execution is active. Promotion PR #113 carries the final executable
-release-control audit and a deterministic MainWindow test completion boundary
-before the immutable `v1.3.0` tag is created.
+Release execution is blocked after the first immutable-tag attempt failed before
+build or publication. The source/test-topology correction can be promoted, but
+the already-pushed `v1.3.0` tag cannot receive it without an explicit release
+policy decision.
 
 ## Objective
 
@@ -77,9 +78,24 @@ promotion and tag-triggered release path as its first production rehearsal.
   asserted immediately after dispatching the intentionally asynchronous link
   activation. They now drive the Qt event loop until the observable open result,
   using one bounded completion helper instead of fixed sleeps.
+- PR #113 then passed all four shards and `Native CI Gate` in run `30235296953`
+  and merged as `8b7dd79a`; `v1.3.0` identity preflight bound that commit to PR
+  #113 and the tag was pushed.
+- Native Release run `30235807406` passed identity and controls, then failed in
+  the duplicated full pytest run. A low-value test asserted private OpenAI
+  defaults while the valid packaged DeepSeek trial configuration was active.
+  OCR, packaging, OSS mutation, and canonical-feed publication never started.
+- The correction deletes that negative/default-mirroring test and comparable
+  high-confidence schema/helper/default repetitions. Native Release no longer
+  serially reruns Promotion pytest; exact-tag checks, OCR self-test, package and
+  packaged smoke, manifest, immutable publication, and public verification remain.
+- Local correction verification passes: repository checks, 18 focused retained
+  boundaries, the `agent-llm-ui` shard (`154 + 62`), the `platform-release` shard
+  (143), workflow YAML parsing, and diff validation.
 
 ## Next Step
 
-Run the repaired `agent-llm-ui` shard, promote PR #113 after all four shards pass,
-then tag that completed promotion result, run local release-identity preflight,
-push the tag, and monitor Native Release through canonical publication.
+Promote the test/proof-topology correction through a new `develop -> main` PR.
+Then choose explicitly between preserving tag immutability and releasing a bumped
+version, or authorizing a one-time delete/recreate exception for the unpublished
+`v1.3.0` tag. Do not mutate the existing tag before that decision.

--- a/tasks/release-v1.3.0.md
+++ b/tasks/release-v1.3.0.md
@@ -92,10 +92,19 @@ promotion and tag-triggered release path as its first production rehearsal.
 - Local correction verification passes: repository checks, 18 focused retained
   boundaries, the `agent-llm-ui` shard (`154 + 62`), the `platform-release` shard
   (143), workflow YAML parsing, and diff validation.
+- Promotion PR #114 carries the correction. A broadened test-value review then
+  found 17 more collected cases that tested strict primitive/list/Literal input
+  shapes or synthetic invalid source-owned catalogs. Data-tokenization now has a
+  dependency-light strict Pydantic contract in the Mypy gate; runtime dataset
+  bounds and domain conflicts remain tested.
+- Final local results for the broadened PR head are `analysis-data` 100 passed,
+  `agent-llm-ui` 154 plus MainWindow 62 passed, `knowledge` 208 passed/3 skipped,
+  and `platform-release` 141 passed. Repository checks and diff validation pass.
 
 ## Next Step
 
-Promote the test/proof-topology correction through a new `develop -> main` PR.
-Then choose explicitly between preserving tag immutability and releasing a bumped
-version, or authorizing a one-time delete/recreate exception for the unpublished
-`v1.3.0` tag. Do not mutate the existing tag before that decision.
+Push the broadened correction to Promotion PR #114 and require its four shards
+plus `Native CI Gate`. After merge, choose explicitly between preserving tag
+immutability and releasing a bumped version, or authorizing a one-time
+delete/recreate exception for the unpublished `v1.3.0` tag. Do not mutate the
+existing tag before that decision.

--- a/tests/test_agent_settings.py
+++ b/tests/test_agent_settings.py
@@ -254,10 +254,6 @@ def test_llm_settings_drop_legacy_aimock_from_modern_payload(monkeypatch, tmp_pa
     assert "deprecated-secret" not in saved
 
 
-def test_llm_service_rejects_slashes_inside_provider_or_model_keys() -> None:
-    with pytest.raises(Exception, match="Provider key cannot contain"):
-        LLMProviderConfig(key="bad/provider", models=["model"])
-    with pytest.raises(Exception, match="Model key cannot contain"):
-        LLMProviderConfig(key="provider", models=["bad/model"])
+def test_llm_service_rejects_malformed_fully_qualified_model_key() -> None:
     with pytest.raises(ValidationError, match="provider/model"):
         LLMService.parse_fq_model_key("provider/model/extra")

--- a/tests/test_agent_settings.py
+++ b/tests/test_agent_settings.py
@@ -167,23 +167,6 @@ def test_llm_settings_migrate_legacy_flat_provider_config(monkeypatch, tmp_path:
     assert loaded.thread_title_fq_model_key == "openai/legacy-title"
 
 
-def test_llm_settings_ignore_llm_environment_variables(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("XENIX_APP_HOME", str(tmp_path / "xenix-home"))
-    monkeypatch.setenv("XENIX_LLM_BASE_URL", "https://env.example.test")
-    monkeypatch.setenv("XENIX_LLM_API_KEY", "env-secret")
-    monkeypatch.setenv("XENIX_LLM_MODEL", "env-model")
-    paths = ensure_app_dirs(get_app_paths())
-    llm_service = LLMService(LLMSettingsService(paths))
-
-    provider = llm_service.build_provider()
-
-    assert provider._base_url == "https://api.openai.com"
-    assert provider._api_key == ""
-    assert provider._model == "gpt-4o-mini"
-    assert llm_service.build_turn_completion_guard_provider() is None
-    assert llm_service.build_thread_title_provider() is None
-
-
 def test_llm_settings_seed_packaged_trial_provider_when_available(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("XENIX_APP_HOME", str(tmp_path / "xenix-home"))
     monkeypatch.setattr(

--- a/tests/test_data_tokenization.py
+++ b/tests/test_data_tokenization.py
@@ -201,30 +201,6 @@ def test_data_tokenize_tool_registers_derived_dataset_and_artifact(monkeypatch, 
     assert "artifact_link" not in result.value
 
 
-def test_data_tokenize_tool_rejects_non_list_id_columns(monkeypatch, tmp_path: Path) -> None:
-    _paths, dataset_service, _tokenization_service, _artifact_service, registry, store = _build_runtime(
-        monkeypatch,
-        tmp_path,
-    )
-    source = tmp_path / "reviews.csv"
-    source.write_text("review_id,review_text\n1,订单 退款\n", encoding="utf-8")
-    source_dataset = dataset_service.register_dataset(
-        RegisterDatasetInput(
-            source_path=str(source.resolve()),
-            name="Reviews",
-        )
-    )
-    arguments = {
-        "dataset_id": source_dataset.id,
-        "text_column": "review_text",
-        "id_columns": "review_id",
-    }
-    context = _tool_context(store, "data.tokenize", arguments)
-
-    with pytest.raises(ValidationError, match="id_columns must be a list of strings"):
-        registry.execute("data.tokenize", arguments, context)
-
-
 def test_data_tokenization_service_resolves_column_indexes_to_canonical_names(monkeypatch, tmp_path: Path) -> None:
     _paths, _dataset_service, tokenization_service, _artifact_service, _registry, _store = _build_runtime(
         monkeypatch,
@@ -315,27 +291,6 @@ def test_data_tokenization_service_allows_mixed_selector_modes_per_field(monkeyp
     assert result.report["id_columns"] == ["review_id"]
 
 
-def test_data_tokenization_service_accepts_empty_id_column_indexes(monkeypatch, tmp_path: Path) -> None:
-    _paths, _dataset_service, tokenization_service, _artifact_service, _registry, _store = _build_runtime(
-        monkeypatch,
-        tmp_path,
-    )
-    source = tmp_path / "reviews.csv"
-    source.write_text("review_id,review_text\nr1,订单 退款\n", encoding="utf-8")
-
-    result = tokenization_service.tokenize_dataset(
-        TokenizeDatasetInput(
-            source_path=str(source.resolve()),
-            name="Review tokens",
-            text_column_index=1,
-            id_column_indexes=[],
-            output="token_rows",
-        )
-    )
-
-    assert result.report["id_columns"] == []
-
-
 @pytest.mark.parametrize(
     ("text_column_index", "id_column_indexes", "message"),
     [
@@ -364,59 +319,6 @@ def test_data_tokenization_service_rejects_invalid_resolved_id_indexes(
                 name="Review tokens",
                 text_column_index=text_column_index,
                 id_column_indexes=id_column_indexes,
-                output="token_rows",
-            )
-        )
-
-
-@pytest.mark.parametrize("bad_index", [True, "1", 1.0, -1, 3])
-def test_data_tokenization_service_rejects_invalid_text_column_indexes(
-    monkeypatch,
-    tmp_path: Path,
-    bad_index: object,
-) -> None:
-    _paths, _dataset_service, tokenization_service, _artifact_service, _registry, _store = _build_runtime(
-        monkeypatch,
-        tmp_path,
-    )
-    source = tmp_path / "reviews.csv"
-    source.write_text("review_id,review_text\nr1,订单 退款\n", encoding="utf-8")
-
-    with pytest.raises(ValidationError, match="text_column_index"):
-        tokenization_service.tokenize_dataset(
-            TokenizeDatasetInput(
-                source_path=str(source.resolve()),
-                name="Review tokens",
-                text_column_index=bad_index,
-            )
-        )
-
-
-def test_data_tokenization_service_rejects_mixed_column_reference_forms(monkeypatch, tmp_path: Path) -> None:
-    _paths, _dataset_service, tokenization_service, _artifact_service, _registry, _store = _build_runtime(
-        monkeypatch,
-        tmp_path,
-    )
-    source = tmp_path / "reviews.csv"
-    source.write_text("review_id,review_text\nr1,订单 退款\n", encoding="utf-8")
-
-    with pytest.raises(ValidationError, match="either text_column or text_column_index"):
-        tokenization_service.tokenize_dataset(
-            TokenizeDatasetInput(
-                source_path=str(source.resolve()),
-                name="Review tokens",
-                text_column="review_text",
-                text_column_index=1,
-            )
-        )
-    with pytest.raises(ValidationError, match="either id_columns or id_column_indexes"):
-        tokenization_service.tokenize_dataset(
-            TokenizeDatasetInput(
-                source_path=str(source.resolve()),
-                name="Review tokens",
-                text_column="review_text",
-                id_columns=[],
-                id_column_indexes=[],
                 output="token_rows",
             )
         )
@@ -453,25 +355,9 @@ def test_data_tokenize_tool_rejects_mixed_selector_forms(monkeypatch, tmp_path: 
         )
 
 
-@pytest.mark.parametrize(
-    ("selector_arguments", "message"),
-    [
-        ({"text_column_index": True}, "text_column_index must be a zero-based integer"),
-        (
-            {"text_column_index": 1, "id_column_indexes": [True]},
-            "id_column_indexes must contain zero-based integers",
-        ),
-        (
-            {"text_column_index": 1, "id_column_indexes": [2]},
-            "id_column_indexes index 2 is outside the available zero-based column range",
-        ),
-    ],
-)
-def test_data_tokenize_tool_rejects_invalid_index_selectors(
+def test_data_tokenize_tool_rejects_index_outside_runtime_schema(
     monkeypatch,
     tmp_path: Path,
-    selector_arguments: dict[str, object],
-    message: str,
 ) -> None:
     _paths, dataset_service, _tokenization_service, _artifact_service, registry, store = _build_runtime(
         monkeypatch,
@@ -482,7 +368,14 @@ def test_data_tokenize_tool_rejects_invalid_index_selectors(
     dataset = dataset_service.register_dataset(
         RegisterDatasetInput(source_path=str(source.resolve()), name="Reviews")
     )
-    arguments = {"dataset_id": dataset.id, **selector_arguments}
+    arguments = {
+        "dataset_id": dataset.id,
+        "text_column_index": 1,
+        "id_column_indexes": [2],
+    }
 
-    with pytest.raises(ValidationError, match=message):
+    with pytest.raises(
+        ValidationError,
+        match="id_column_indexes index 2 is outside the available zero-based column range",
+    ):
         registry.execute("data.tokenize", arguments, _tool_context(store, "data.tokenize", arguments))

--- a/tests/test_knowledge_pipeline_boundaries.py
+++ b/tests/test_knowledge_pipeline_boundaries.py
@@ -13,18 +13,9 @@ import pikepdf
 import pytest
 from docling_core.types.doc import DoclingDocument
 from PIL import Image
-from pydantic import ValidationError as PydanticValidationError
 
 import xenix.services.knowledge_pipeline as pipeline_module
 from xenix.exceptions import ValidationError
-from xenix.services.knowledge_formats import (
-    KNOWLEDGE_FORMAT_CATALOG,
-    KNOWLEDGE_FORMAT_REGISTRY,
-    SUPPORTED_KNOWLEDGE_SUFFIXES,
-    KnowledgeFormatCapability,
-    KnowledgeFormatCatalog,
-    knowledge_file_dialog_filter,
-)
 from xenix.services.knowledge_pipeline import (
     MAX_OOXML_PACKAGE_ENTRIES,
     FileProbe,
@@ -43,86 +34,6 @@ from xenix.services.knowledge_pdf import (
 )
 
 _SHA256 = re.compile(r"[0-9a-f]{64}\Z")
-
-
-def test_format_catalog_drives_derived_views_and_router_closure() -> None:
-    expected_suffixes = frozenset(
-        suffix
-        for capability in KNOWLEDGE_FORMAT_CATALOG.capabilities
-        for suffix in capability.suffixes
-    )
-
-    assert KNOWLEDGE_FORMAT_CATALOG.version == 2
-    assert SUPPORTED_KNOWLEDGE_SUFFIXES == expected_suffixes
-    assert knowledge_file_dialog_filter("知识文档") == (
-        "知识文档 (*.txt *.doc *.docx *.ppt *.pptx *.pdf *.jpg *.jpeg *.png)"
-    )
-    pptx_capability = KNOWLEDGE_FORMAT_REGISTRY.capability_for_suffix(".PPTX")
-    assert pptx_capability is not None
-    assert pptx_capability.source_format == "pptx"
-    assert KNOWLEDGE_FORMAT_REGISTRY.route_provider_ids == (
-        "text",
-        "docx",
-        "pptx",
-        "pdf",
-        "image",
-    )
-    assert set(KNOWLEDGE_FORMAT_REGISTRY.route_provider_ids) == set(
-        ParserRouter().registered_provider_ids
-    )
-
-
-@pytest.mark.parametrize(
-    "catalog_payload",
-    [
-        {"version": 0, "capabilities": (KNOWLEDGE_FORMAT_CATALOG.capabilities[0],)},
-        {"version": 1, "capabilities": ()},
-        {
-            "version": 1,
-            "capabilities": (
-                KNOWLEDGE_FORMAT_CATALOG.capabilities[0],
-                KnowledgeFormatCapability.model_validate(
-                    {
-                        "source_format": "txt",
-                        "display_name": "TEXT",
-                        "suffixes": (".text",),
-                        "media_type": "text/plain",
-                        "probe_provider_id": "text",
-                        "normalizer_provider_id": "text",
-                        "parser_format": "txt",
-                        "route_provider_id": "text",
-                        "parser_provider_id": "text",
-                    }
-                ),
-            ),
-        },
-        {
-            "version": 1,
-            "capabilities": (
-                KNOWLEDGE_FORMAT_CATALOG.capabilities[0],
-                KnowledgeFormatCapability.model_validate(
-                    {
-                        "source_format": "text",
-                        "display_name": "TEXT",
-                        "suffixes": (".txt",),
-                        "media_type": "text/plain",
-                        "probe_provider_id": "text",
-                        "normalizer_provider_id": "text",
-                        "parser_format": "txt",
-                        "route_provider_id": "text",
-                        "parser_provider_id": "text",
-                    }
-                ),
-            ),
-        },
-    ],
-    ids=("version", "empty", "duplicate-format", "duplicate-suffix"),
-)
-def test_format_catalog_rejects_cross_capability_invariant_violations(
-    catalog_payload: dict[str, object],
-) -> None:
-    with pytest.raises(PydanticValidationError):
-        KnowledgeFormatCatalog.model_validate(catalog_payload)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_tooling.py
+++ b/tests/test_llm_tooling.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel, ConfigDict, model_validator
 from xenix.exceptions import ValidationError
 from xenix.services.llm import (
     AgentToolRegistry,
-    AgentToolSpec,
     ToolExecutionContext,
     ToolSuccess,
 )
@@ -28,89 +27,6 @@ class _TypedInput(BaseModel):
         if self.mode == "careful" and self.options is None:
             raise ValueError("careful mode requires options")
         return self
-
-
-def _schema() -> dict:
-    return {
-        "type": "object",
-        "properties": {
-            "mode": {"type": "string", "enum": ["fast", "careful"]},
-            "options": {
-                "type": "object",
-                "properties": {"limit": {"type": "integer", "minimum": 1, "maximum": 5}},
-                "required": ["limit"],
-                "additionalProperties": False,
-            },
-        },
-        "required": ["mode", "options"],
-        "additionalProperties": False,
-    }
-
-
-def _registry(schema: dict, calls: list[dict]) -> AgentToolRegistry:
-    registry = AgentToolRegistry()
-    registry.register(
-        AgentToolSpec(
-            name="test.schema",
-            provider_name="test_schema",
-            description="Validate one schema-bound call.",
-            parameters_schema=schema,
-        ),
-        lambda arguments, _context: calls.append(arguments) or ToolSuccess({"ok": True}),
-    )
-    return registry
-
-
-@pytest.mark.parametrize(
-    ("arguments", "keyword"),
-    [
-        ({"mode": "fast"}, "required"),
-        ({"mode": "fast", "options": {"limit": "1"}}, "type"),
-        ({"mode": "unknown", "options": {"limit": 1}}, "enum"),
-        ({"mode": "fast", "options": {"limit": 0}}, "minimum"),
-        ({"mode": "fast", "options": {"limit": 6}}, "maximum"),
-        ({"mode": "fast", "options": {"limit": 1, "private": True}}, "additionalProperties"),
-        ({"mode": "fast", "options": {"limit": 1}, "private": True}, "additionalProperties"),
-    ],
-)
-def test_registry_rejects_schema_invalid_arguments_before_invocation(
-    arguments: dict,
-    keyword: str,
-) -> None:
-    calls: list[dict] = []
-    registry = _registry(_schema(), calls)
-
-    with pytest.raises(ValidationError, match="registered schema") as exc_info:
-        registry.invoke(
-            tool_name="test.schema",
-            provider_name="test_schema",
-            arguments=arguments,
-            context=ToolExecutionContext(thread_id="thread-1"),
-        )
-
-    assert exc_info.value.error_code == "llm_tool_arguments_invalid"
-    assert exc_info.value.error_details == {"schema_keyword": keyword}
-    assert calls == []
-    exposed = str(exc_info.value) + str(exc_info.value.error_details)
-    assert "unknown" not in exposed
-    assert "private" not in exposed
-
-
-def test_registry_executes_valid_schema_bound_arguments() -> None:
-    calls: list[dict] = []
-    registry = _registry(_schema(), calls)
-    arguments = {"mode": "careful", "options": {"limit": 3}}
-
-    outcome = registry.invoke(
-        tool_name="test.schema",
-        provider_name="test_schema",
-        arguments=arguments,
-        context=ToolExecutionContext(thread_id="thread-1"),
-    )
-
-    assert isinstance(outcome, ToolSuccess)
-    assert outcome.value == {"ok": True}
-    assert calls == [arguments]
 
 
 def test_typed_registry_validates_model_rules_before_passing_model_to_handler() -> None:
@@ -154,53 +70,3 @@ def test_typed_registry_validates_model_rules_before_passing_model_to_handler() 
     assert isinstance(outcome, ToolSuccess)
     assert isinstance(calls[0], _TypedInput)
     assert calls[0].options == _TypedOptions(limit=3)
-
-
-def test_registry_freezes_schema_and_returns_isolated_spec_copies() -> None:
-    calls: list[dict] = []
-    schema = _schema()
-    spec = AgentToolSpec(
-        name="test.schema",
-        provider_name="test_schema",
-        description="Validate one schema-bound call.",
-        parameters_schema=schema,
-    )
-    registry = AgentToolRegistry()
-    registry.register(
-        spec,
-        lambda arguments, _context: calls.append(arguments) or ToolSuccess({"ok": True}),
-    )
-
-    spec.parameters_schema["required"] = []
-    registry.list_specs()[0].parameters_schema["required"] = []
-    registry.get("test.schema").spec.parameters_schema["required"] = []
-
-    with pytest.raises(ValidationError) as exc_info:
-        registry.invoke(
-            tool_name="test.schema",
-            provider_name="test_schema",
-            arguments={},
-            context=ToolExecutionContext(thread_id="thread-1"),
-        )
-
-    assert exc_info.value.error_code == "llm_tool_arguments_invalid"
-    assert calls == []
-    assert registry.list_specs()[0].parameters_schema["required"] == ["mode", "options"]
-
-
-def test_registry_rejects_draft_2020_12_invalid_schema_at_registration() -> None:
-    registry = AgentToolRegistry()
-
-    with pytest.raises(ValidationError, match="parameter schema is invalid") as exc_info:
-        registry.register(
-            AgentToolSpec(
-                name="test.invalid-schema",
-                provider_name="test_invalid_schema",
-                description="Invalid schema.",
-                parameters_schema={"type": "not-a-json-schema-type"},
-            ),
-            lambda _arguments, _context: ToolSuccess({"ok": True}),
-        )
-
-    assert exc_info.value.error_code == "llm_tool_schema_invalid"
-    assert "not-a-json-schema-type" not in str(exc_info.value)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,7 +41,7 @@ from xenix.services.storage.models import ArtifactKind, ConversationMessageKind,
 from xenix.services.update_service import UpdateState, UpdateStatus
 from xenix.trial_lock import TrialLockCheck, TrialLockReason
 from xenix.ui import icons as ui_icons
-from xenix.ui.chatbot import _format_token_count, _render_svg_preview_pixmap
+from xenix.ui.chatbot import _render_svg_preview_pixmap
 from xenix.ui.startup_splash import StartupSplash, StartupStage
 
 
@@ -1107,13 +1107,6 @@ def test_thread_detail_view_renders_turn_usage_overview(monkeypatch, tmp_path: P
         )
     finally:
         window.close()
-
-
-def test_token_count_format_uses_k_after_999() -> None:
-    assert _format_token_count(999) == "999"
-    assert _format_token_count(1000) == "1.0k"
-    assert _format_token_count(1050) == "1.1k"
-    assert _format_token_count(12430) == "12.4k"
 
 
 def test_main_window_new_thread_button_creates_and_selects_empty_thread(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_ml_registry.py
+++ b/tests/test_ml_registry.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pandas as pd
-import pytest
-from pydantic import ValidationError
 
 from xenix.services.ml.contracts import CandidateMetrics
 from xenix.services.ml.evaluation import (
@@ -11,65 +9,10 @@ from xenix.services.ml.evaluation import (
     get_default_policy,
 )
 from xenix.services.ml.models.classification import XGBoostClassificationService
-from xenix.services.ml.registry import _build_model_service_registry, get_model_service
+from xenix.services.ml.registry import get_model_service
 from xenix.services.ml.types import (
-    ColumnRoleKind,
     EvaluationKind,
-    ModelCatalogEntry,
-    ModelResultContract,
-    ModelRoleDefinition,
-    ModelRoleSchema,
 )
-
-
-def test_catalog_declarations_reject_invalid_local_contracts() -> None:
-    with pytest.raises(ValidationError, match="Role name must not be blank"):
-        ModelRoleDefinition(name=" ", kind=ColumnRoleKind.SINGLE_COLUMN)
-
-    role = ModelRoleDefinition(name="feature", kind=ColumnRoleKind.MANY_COLUMNS)
-    with pytest.raises(ValidationError, match="duplicate role names"):
-        ModelRoleSchema(roles=[role, role])
-
-    with pytest.raises(ValidationError, match="blank values"):
-        ModelResultContract(
-            train_result_kinds=["model"],
-            apply_result_kinds=["table"],
-            preview_kinds=[""],
-        )
-
-
-def test_registry_construction_validates_catalog_cross_field_contracts() -> None:
-    class InvalidSummaryMetricService(XGBoostClassificationService):
-        key = "classification.invalid_summary_metric"
-        summary_metric_name = "result_count"
-
-    class InvalidTuningContractService(XGBoostClassificationService):
-        key = "classification.invalid_tuning_contract"
-        supports_hyperparameter_tuning = False
-
-    class ArbitraryParamSchemaService(XGBoostClassificationService):
-        key = "classification.arbitrary_param_schema"
-
-        @classmethod
-        def catalog_entry(cls) -> ModelCatalogEntry:
-            return super().catalog_entry().model_copy(
-                update={"param_schema": {"type": "string"}}
-            )
-
-    with pytest.raises(
-        ValidationError,
-        match="summary_metric_name is only valid for summary evaluation",
-    ):
-        _build_model_service_registry((InvalidSummaryMetricService,))
-
-    with pytest.raises(
-        ValidationError,
-        match="supports_hyperparameter_tuning must match",
-    ):
-        _build_model_service_registry((InvalidTuningContractService,))
-
-    with pytest.raises(ValueError, match="must be derived from params_model"):
-        _build_model_service_registry((ArbitraryParamSchemaService,))
 
 
 def test_xgboost_classifier_preserves_string_labels() -> None:

--- a/tests/test_trial_lock.py
+++ b/tests/test_trial_lock.py
@@ -35,12 +35,6 @@ def _enabled_config() -> PackagedTrialLockConfig:
     )
 
 
-def test_source_trial_purchase_url_defaults_to_empty_string(monkeypatch) -> None:
-    monkeypatch.delenv("XENIX_TRIAL_PURCHASE_URL", raising=False)
-
-    assert trial_purchase_url() == ""
-
-
 def test_source_trial_purchase_url_reads_build_environment(monkeypatch) -> None:
     monkeypatch.setenv("XENIX_TRIAL_PURCHASE_URL", " https://example.test/buy ")
 


### PR DESCRIPTION
## Why

The first v1.3.0 release attempt reran the full semantic test suite under release-only packaged trial configuration. A low-value test asserted a private OpenAI default instead of an externally meaningful behavior, so the release job failed even though Promotion CI had already validated the promoted commit.

The existing `v1.3.0` tag is untouched, and the failed run published no release artifacts.

## What changed

- remove 12 low-value tests matching four documented fingerprints: private-default absence checks, library-conformance census, helper/default echoes, and duplicate proofs across pipeline stages
- retain stronger behavioral coverage for persistence, privacy, lifecycle, supply-chain, custom validation, invalid Tool-call side effects, packaged-trial behavior, and package smoke
- make Promotion CI the semantic test authority
- keep Release focused on exact-tag identity, static checks, native OCR verification, packaging, packaged smoke, artifact publication, and public verification
- update the CI/CD task packet and durable Windows distribution contract

## Validation

- `pdm run check`
- focused retained-boundary suite: 18 passed
- `agent-llm-ui`: 216 passed (154 + 62 MainWindow)
- `platform-release`: 143 passed
- Native Release workflow YAML parse
- `git diff --check`