### PR TITLE
Publish v1.3.2 with content-addressed OCR artifacts

### DIFF
--- a/docs/40-deployment/windows-distribution.md
+++ b/docs/40-deployment/windows-distribution.md
@@ -113,6 +113,11 @@ The app package embeds only the native OCR catalog. The manifest admits the OCR
 archive from its approved output root as a typed artifact and fails if catalog
 and archive identity disagree.
 
+The OCR catalog names its archive by runtime ID plus the archive's complete
+SHA-256. The public object key is therefore content-addressed: separate build
+bytes can coexist safely, while each packaged client remains bound to one exact
+catalog hash.
+
 Packaged smoke installs the already-built locked OCR generation offline, runs its
 native self-test and golden-image recognition through the spawned Knowledge
 worker, imports the image, derives bounded Units, reaches keyword lookup, and

--- a/native/knowledge_ocr/README.md
+++ b/native/knowledge_ocr/README.md
@@ -7,7 +7,9 @@ not part of the desktop application's Python environment.
 Run `pdm run build-knowledge-ocr` from a Developer PowerShell with the pinned MSVC
 toolchain available. The build verifies every downloaded byte, applies the reviewed
 compatibility patch, executes the real stdio protocol checks, and writes the
-deterministic archive plus `runtime_catalog.json` under `dist/knowledge-ocr/`.
+normalized archive plus `runtime_catalog.json` under `dist/knowledge-ocr/`. The
+archive name includes its complete SHA-256, so rebuilt runtime bytes never collide
+with an earlier immutable object that has the same logical runtime ID.
 
 The application downloads only that Xenix-built archive from its configured release
 origin. It never installs Python, pip, Paddle packages, or models on an end-user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xenix-native"
-version = "1.3.1"
+version = "1.3.2"
 description = "Xenix native"
 authors = [{ name = "Lan_zhijiang", email = "lanzhijiang@foxmail.com" }]
 readme = "README.md"

--- a/scripts/build_knowledge_ocr_runtime.py
+++ b/scripts/build_knowledge_ocr_runtime.py
@@ -46,6 +46,10 @@ REQUIRED_DOWNLOADS = {
 }
 
 
+def _content_addressed_artifact_name(runtime_id: str, artifact_sha256: str) -> str:
+    return f"xenix-knowledge-ocr-win-x64-{runtime_id}-{artifact_sha256}.zip"
+
+
 class _LockDocument(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
@@ -160,6 +164,18 @@ class KnowledgeOcrRuntimeCatalog(_LockDocument):
         if not value or value in {".", ".."} or Path(value).name != value:
             raise ValueError("Artifact name must be a safe file name.")
         return value
+
+    @model_validator(mode="after")
+    def _artifact_name_must_match_content_identity(self) -> Self:
+        expected = _content_addressed_artifact_name(
+            self.runtime_id,
+            self.artifact_sha256,
+        )
+        if self.artifact_name != expected:
+            raise ValueError(
+                "Artifact name must include the runtime and content identities."
+            )
+        return self
 
 
 def sha256_file(path: Path) -> str:
@@ -716,13 +732,18 @@ def verify_runtime(runtime: Path, golden_image: Path) -> None:
     log.unlink(missing_ok=True)
 
 
-def write_deterministic_archive(runtime: Path, destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = destination.with_name(f".{destination.name}.{uuid4().hex}.tmp")
+def write_content_addressed_archive(
+    runtime: Path,
+    output: Path,
+    *,
+    runtime_id: str,
+) -> Path:
+    output.mkdir(parents=True, exist_ok=True)
+    temporary = output / f".knowledge-ocr-{uuid4().hex}.zip"
     try:
         with zipfile.ZipFile(
             temporary,
-            "w",
+            "x",
             compression=zipfile.ZIP_DEFLATED,
             compresslevel=9,
         ) as package:
@@ -734,7 +755,19 @@ def write_deterministic_archive(runtime: Path, destination: Path) -> None:
                 info.compress_type = zipfile.ZIP_DEFLATED
                 info.external_attr = 0o100644 << 16
                 package.writestr(info, path.read_bytes(), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
-        os.replace(temporary, destination)
+        artifact_sha256 = sha256_file(temporary)
+        destination = output / _content_addressed_artifact_name(
+            runtime_id,
+            artifact_sha256,
+        )
+        if destination.exists():
+            if sha256_file(destination) != artifact_sha256:
+                raise RuntimeError(
+                    "Knowledge OCR content-addressed artifact conflicts with existing output."
+                )
+        else:
+            os.replace(temporary, destination)
+        return destination
     finally:
         temporary.unlink(missing_ok=True)
 
@@ -833,9 +866,11 @@ def build(args: argparse.Namespace) -> tuple[Path, Path]:
         vcomp140=vcomp,
     )
     verify_runtime(runtime, downloads["golden_image"])
-    artifact_name = f"xenix-knowledge-ocr-win-x64-{lock.runtime_id}.zip"
-    archive = output / artifact_name
-    write_deterministic_archive(runtime, archive)
+    archive = write_content_addressed_archive(
+        runtime,
+        output,
+        runtime_id=lock.runtime_id,
+    )
     catalog = output / "runtime_catalog.json"
     write_catalog(lock, archive, catalog)
     return archive, catalog

--- a/tasks/release-v1.3.1.md
+++ b/tasks/release-v1.3.1.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Ready for the `develop -> main` Promotion PR. The accepted CI/test portfolio and
-headed Agent Harness benchmark have unlocked the v1.3.1 version mutation. Tag
-creation and release execution still wait for the promoted Native CI result.
+Consumed by a safe publication failure. `v1.3.1` remains immutable at main
+promotion commit `6760286f`; it is not publicly visible because the publisher
+failed before updating the canonical feed.
 
 ## Objective
 
@@ -15,8 +15,8 @@ proportionate to the product and the redesigned proof portfolio passes.
 
 - Never move or delete `v1.3.0`; it remains the immutable identity of the failed,
   unpublished attempt.
-- Do not create `v1.3.1`, enter the release Environment, or mutate OSS/public
-  feeds before the redesigned Native CI passes on the promotion PR.
+- Never move or delete `v1.3.1`, overwrite its uploaded package, or overwrite the
+  conflicting shared OCR object.
 - Preserve the promoted product/release history and use a new
   `develop -> main` Promotion PR for the accepted CI/test architecture.
 - Preserve unrelated user worktree changes.
@@ -27,9 +27,9 @@ proportionate to the product and the redesigned proof portfolio passes.
 - Boundary models and static analysis own input-shape facts; semantic tests own
   user outcomes, state, side effects, and trust-boundary failure behavior.
 - The agreed Promotion duration budgets pass the required qualifying sample.
-- A final promoted main result declares v1.3.1 and passes release identity
-  preflight before the immutable tag is pushed.
-- Native Release publishes and publicly verifies v1.3.1 without moving v1.3.0.
+- The canonical feed remains v1.2.0.
+- The successor release uses a content-addressed OCR object key and does not
+  mutate either conflicting object.
 
 ## Current Truth
 
@@ -42,10 +42,14 @@ proportionate to the product and the redesigned proof portfolio passes.
 - Local acceptance passed `pdm run test`, `pdm run check`, and `pdm run smoke`.
   The visible benchmark also exercised real file import, the configured external
   LLM, chart work, and knowledge retrieval through the actual desktop UI.
-- `pyproject.toml` now declares `1.3.1`; the immutable tag remains uncreated.
+- PR #115 passed Native CI and produced main promotion commit `6760286f`.
+- Local and remote release identity checks bound `v1.3.1` to that commit and PR.
+- Native OCR build, package, and packaged smoke passed in run `30258978782`.
+- The publisher uploaded and verified the v1.3.1 full package, then failed closed
+  because the current OCR archive and an existing immutable OCR object shared a
+  runtime-only key but had different size and SHA-256.
+- The canonical feed still declares v1.2.0; v1.3.1 never became visible.
 
 ## Next Step
 
-Promote this result through a `develop -> main` PR, require Native CI to pass,
-then create and locally verify `v1.3.1` on the eligible main promotion result
-before pushing the immutable tag.
+Publish the content-addressing correction as a new v1.3.2 promotion and release.

--- a/tasks/release-v1.3.2.md
+++ b/tasks/release-v1.3.2.md
@@ -1,0 +1,47 @@
+# v1.3.2 Release Packet
+
+## Status
+
+Implementing the content-addressed Knowledge OCR artifact correction before a new
+`develop -> main` promotion.
+
+## Objective
+
+Publish Xenix Native v1.3.2 without colliding with an earlier immutable OCR
+runtime object that has the same logical runtime ID but different build bytes.
+
+## Guardrails
+
+- Preserve the immutable v1.3.0 and v1.3.1 tags and every uploaded object.
+- Do not update the canonical feed until the full v1.3.2 publisher succeeds.
+- Keep runtime ID, model pack ID, protocol, client installation, and catalog
+  authority unchanged; change only the archive's public content identity.
+- Use the existing 30-case portfolio and static checks; do not add a publication
+  regression case.
+- Preserve unrelated user worktree changes.
+
+## Verification
+
+- The producer catalog rejects an artifact name that does not equal
+  `<runtime-id>-<complete archive SHA-256>.zip`.
+- `pdm run test`, `pdm run check`, and `pdm run smoke` pass.
+- Promotion Native CI passes on a `develop -> main` PR.
+- Release identity binds `v1.3.2` to that main promotion and its PR.
+- Native OCR build, packaged smoke, immutable upload, public SHA-256/Range checks,
+  and canonical feed publication all pass.
+
+## Current Truth
+
+- v1.3.1 run `30258978782` safely failed before feed visibility.
+- The existing OCR object is 205,199,984 bytes with SHA-256 beginning `50800E0C`;
+  the v1.3.1 build is 205,199,982 bytes with SHA-256 beginning `5C8992F5`.
+- ZIP entry metadata is normalized, but compiled native bytes are not assumed to
+  be reproducible across rebuilds. Runtime ID alone is therefore not a complete
+  immutable object identity.
+- The embedded catalog already owns artifact name, byte count, and SHA-256; the
+  client generation ID already incorporates the artifact SHA-256.
+
+## Next Step
+
+Validate the producer and existing portfolio, then promote v1.3.2 through Native
+CI before creating its immutable tag.


### PR DESCRIPTION
## Summary
- name each Knowledge OCR archive with its logical runtime ID and complete SHA-256
- enforce the runtime/content-address relationship in the producer catalog model
- advance the successor release to v1.3.2 while preserving the consumed v1.3.1 tag and uploaded objects

## Root cause
The v1.3.1 publisher correctly rejected an OCR object whose runtime-only key already existed with different bytes. ZIP metadata is normalized, but native build output is not assumed to be byte-reproducible across rebuilds; runtime ID alone was therefore an incomplete immutable object identity.

## Impact
The embedded catalog remains the artifact authority and clients remain bound to its exact byte count and SHA-256. Runtime protocol, model pack, installation generation, and the existing v1.2.0/v1.3.1 objects are unchanged.

## Verification
- content-addressed archive/catalog boundary probe: passed
- pdm lock --check: passed
- pdm run check: passed
- pdm run test: 30 passed
- pdm run smoke: passed
- no new regression case added, per product decision