### PR TITLE
Release v1.3.3: self-contained native OCR runtime

### DIFF
--- a/docs/20-product-tdd/knowledge-base-boundary.md
+++ b/docs/20-product-tdd/knowledge-base-boundary.md
@@ -40,14 +40,16 @@ canonical-ready generation
   OCR is ready. Xenix does not claim generic complex-layout understanding from this
   classifier alone.
 - Local OCR uses one optional, one-click-installed archive containing an
-  Xenix-owned native worker built on official Paddle Inference C++, its complete
-  dependency closure, and an explicitly identified model pack. Setup verifies the
-  catalog, archive, member manifest, protocol, and self-test before atomic
-  activation. Deployment consumes one bundle source that binds catalog authority to
-  either the generated local development archive or the immutable release origin;
-  transport cannot bypass deployment-owned integrity gates. `ready` additionally
-  requires a compact content-addressed generation directory and a self-test executed
-  at that final Windows path before active-pointer publication, plus a
+  Xenix-owned native worker built on official Paddle Inference C++, its compiled-in
+  fixed pipeline configuration, complete dependency closure, and an explicitly
+  identified model pack. Setup verifies the catalog, archive, member manifest,
+  protocol, and self-test before atomic activation. The worker does not resolve a
+  pipeline config from the build tree, its working directory, or a companion file.
+  Deployment consumes one bundle source that binds catalog authority to either the
+  generated local development archive or the immutable release origin; transport
+  cannot bypass deployment-owned integrity gates. `ready` additionally requires a
+  compact content-addressed generation directory and a self-test executed at that
+  final Windows path before active-pointer publication, plus a
   freshness-bounded verification
   record produced by full member hashing and self-test; missing/stale evidence is
   refreshed off the UI thread. Canonical provenance records the exact runtime,

--- a/docs/40-deployment/runtime-state.md
+++ b/docs/40-deployment/runtime-state.md
@@ -100,7 +100,10 @@ remain import-owned; index build detail and retry remain index-service-owned.
 Local OCR setup downloads only the immutable artifact named by the catalog embedded
 in the installed Xenix build. It verifies the outer size/digest, safe archive shape,
 runtime member manifest, runtime/model/protocol identities, and native self-test in
-staging before replacing `active.json`. A separate verification record binds the
+staging before replacing `active.json`. The fixed OCR pipeline configuration is
+compiled into the worker, so it cannot be resolved from a build-tree path, process
+working directory, or companion configuration file. A separate verification record
+binds the
 active generation, model, engine/protocol, and manifest hash to a recent full member
 scan and self-test. Fast status reads only bounded manifests/that record; absent or
 stale verification reports `checking` and is refreshed in a background task before

--- a/docs/40-deployment/windows-distribution.md
+++ b/docs/40-deployment/windows-distribution.md
@@ -123,7 +123,10 @@ native self-test and golden-image recognition through the spawned Knowledge
 worker, imports the image, derives bounded Units, reaches keyword lookup, and
 checks the recorded runtime generation. It also imports valid DOCX and PPTX
 documents through the frozen worker and retrieves bounded presentation text.
-Activation or a parser-helper exercise alone is insufficient.
+Native runtime verification runs the extracted worker from a foreign working
+directory after the builder PaddleOCR checkout has been made unavailable, and scans
+released binaries for real builder paths. Activation or a parser-helper exercise
+alone is insufficient.
 
 ## GitHub Controls
 

--- a/native/knowledge_ocr/CMakeLists.txt
+++ b/native/knowledge_ocr/CMakeLists.txt
@@ -12,10 +12,24 @@ endif()
 if(NOT XENIX_PADDLEOCR_SOURCE)
   message(FATAL_ERROR "Set XENIX_PADDLEOCR_SOURCE to the pinned PaddleOCR checkout")
 endif()
+if(NOT XENIX_BUILD_WORKSPACE)
+  message(FATAL_ERROR "Set XENIX_BUILD_WORKSPACE to the disposable native build root")
+endif()
 
 set(_cpp_infer "${XENIX_PADDLEOCR_SOURCE}/deploy/cpp_infer")
 if(NOT EXISTS "${_cpp_infer}/CMakeLists.txt")
   message(FATAL_ERROR "The PaddleOCR C++ inference source was not found")
+endif()
+
+# PaddleOCR and SDK headers use __FILE__ in diagnostics. Map the entire disposable
+# build root to a stable virtual label so the worker never discloses local or CI
+# source, SDK, or CMake paths.
+if(MSVC)
+  file(TO_NATIVE_PATH "${XENIX_BUILD_WORKSPACE}" _workspace_native)
+  add_compile_options(
+    "/experimental:deterministic"
+    "/pathmap:${_workspace_native}=X:\\xenix\\native-build"
+  )
 endif()
 
 # The build operates on a disposable, hash-pinned checkout. Keep the upstream

--- a/native/knowledge_ocr/README.md
+++ b/native/knowledge_ocr/README.md
@@ -9,7 +9,11 @@ toolchain available. The build verifies every downloaded byte, applies the revie
 compatibility patch, executes the real stdio protocol checks, and writes the
 normalized archive plus `runtime_catalog.json` under `dist/knowledge-ocr/`. The
 archive name includes its complete SHA-256, so rebuilt runtime bytes never collide
-with an earlier immutable object that has the same logical runtime ID.
+with an earlier immutable object that has the same logical runtime ID. The fixed
+Xenix OCR pipeline configuration is compiled into the worker; the archive contains
+only the worker, its dependency closure, and model assets. Build verification runs
+the extracted worker without the PaddleOCR checkout and from a foreign working
+directory, and rejects real builder paths in released binaries.
 
 The application downloads only that Xenix-built archive from its configured release
 origin. It never installs Python, pip, Paddle packages, or models on an end-user

--- a/native/knowledge_ocr/patches/paddleocr-v3.7.0-xenix.patch
+++ b/native/knowledge_ocr/patches/paddleocr-v3.7.0-xenix.patch
@@ -36,3 +36,39 @@ index 5283c4a..63b42f8 100644
 -
 +
    if (!__g_logger.logger_directory.empty()) {
+
+diff --git a/deploy/cpp_infer/src/utils/utility.cc b/deploy/cpp_infer/src/utils/utility.cc
+index 4439c47..e33e9f2 100644
+--- a/deploy/cpp_infer/src/utils/utility.cc
++++ b/deploy/cpp_infer/src/utils/utility.cc
+@@ -82,26 +82,10 @@ Utility::FindModelPath(const std::string &model_dir,
+ }
+ absl::StatusOr<std::string>
+ Utility::GetDefaultConfig(std::string pipeline_name) {
+-  std::string current_path = __FILE__;
+-  for (int i = 0; i < 2; i++) {
+-    size_t pos = current_path.find_last_of(PATH_SEPARATOR);
+-    if (pos == std::string::npos) {
+-      return absl::NotFoundError("Could not find pipeline config yaml :" +
+-                                 pipeline_name);
+-    }
+-    current_path = current_path.substr(0, pos);
+-  }
+-  std::string config_path_yaml = current_path + PATH_SEPARATOR + "configs" +
+-                                 PATH_SEPARATOR + pipeline_name + ".yaml";
+-  std::string config_path_yml = current_path + PATH_SEPARATOR + "configs" +
+-                                PATH_SEPARATOR + pipeline_name + ".yml";
+-  if (FileExists(config_path_yaml).ok()) {
+-    return config_path_yaml;
+-  } else if (FileExists(config_path_yml).ok()) {
+-    return config_path_yml;
+-  }
+-  return absl::NotFoundError("Could not find pipeline config yaml :" +
+-                             pipeline_name);
++  return absl::FailedPreconditionError(
++      "Default pipeline configuration is unavailable; provide an explicit "
++      "PaddleX configuration for " +
++      pipeline_name + ".");
+ }
+ absl::StatusOr<std::string>
+ Utility::GetConfigPaths(const std::string &model_dir,

--- a/native/knowledge_ocr/src/main.cpp
+++ b/native/knowledge_ocr/src/main.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "src/pipelines/ocr/pipeline.h"
@@ -23,6 +24,55 @@ constexpr std::uint32_t kMaxMessageBytes = 16U * 1024U * 1024U;
 constexpr const char *kRuntimeId =
     "paddle-inference-3.3.0-paddleocr-3.7.0-win-x64";
 constexpr const char *kModelPackId = "pp-ocrv6-medium-zh-en-1";
+
+const std::unordered_map<std::string, std::string> &XenixPipelineConfig() {
+  // Flattened from PaddleOCR v3.7.0's deploy/cpp_infer/src/configs/OCR.yaml.
+  // The caller overrides the optional document and textline stages below.
+  static const std::unordered_map<std::string, std::string> config = {
+      {"pipeline_name", "OCR"},
+      {"text_type", "general"},
+      {"use_doc_preprocessor", "True"},
+      {"use_textline_orientation", "True"},
+      {"SubPipelines.DocPreprocessor.pipeline_name", "doc_preprocessor"},
+      {"SubPipelines.DocPreprocessor.use_doc_orientation_classify", "True"},
+      {"SubPipelines.DocPreprocessor.use_doc_unwarping", "True"},
+      {"SubPipelines.DocPreprocessor.SubModules.DocOrientationClassify."
+       "module_name",
+       "doc_text_orientation"},
+      {"SubPipelines.DocPreprocessor.SubModules.DocOrientationClassify."
+       "model_name",
+       "PP-LCNet_x1_0_doc_ori"},
+      {"SubPipelines.DocPreprocessor.SubModules.DocOrientationClassify."
+       "model_dir",
+       "null"},
+      {"SubPipelines.DocPreprocessor.SubModules.DocUnwarping.module_name",
+       "image_unwarping"},
+      {"SubPipelines.DocPreprocessor.SubModules.DocUnwarping.model_name",
+       "UVDoc"},
+      {"SubPipelines.DocPreprocessor.SubModules.DocUnwarping.model_dir",
+       "null"},
+      {"SubModules.TextDetection.module_name", "text_detection"},
+      {"SubModules.TextDetection.model_name", "PP-OCRv6_medium_det"},
+      {"SubModules.TextDetection.model_dir", "null"},
+      {"SubModules.TextDetection.limit_side_len", "64"},
+      {"SubModules.TextDetection.limit_type", "min"},
+      {"SubModules.TextDetection.max_side_limit", "4000"},
+      {"SubModules.TextDetection.thresh", "0.3"},
+      {"SubModules.TextDetection.box_thresh", "0.6"},
+      {"SubModules.TextDetection.unclip_ratio", "1.5"},
+      {"SubModules.TextLineOrientation.module_name", "textline_orientation"},
+      {"SubModules.TextLineOrientation.model_name",
+       "PP-LCNet_x1_0_textline_ori"},
+      {"SubModules.TextLineOrientation.model_dir", "null"},
+      {"SubModules.TextLineOrientation.batch_size", "6"},
+      {"SubModules.TextRecognition.module_name", "text_recognition"},
+      {"SubModules.TextRecognition.model_name", "PP-OCRv6_medium_rec"},
+      {"SubModules.TextRecognition.model_dir", "null"},
+      {"SubModules.TextRecognition.batch_size", "6"},
+      {"SubModules.TextRecognition.score_thresh", "0.0"},
+  };
+  return config;
+}
 
 class Engine {
 public:
@@ -45,6 +95,8 @@ public:
     params.text_detection_model_dir = detection;
     params.text_recognition_model_name = "PP-OCRv6_medium_rec";
     params.text_recognition_model_dir = recognition;
+    params.paddlex_config =
+        Utility::PaddleXConfigVariant(XenixPipelineConfig());
     params.use_doc_orientation_classify = false;
     params.use_doc_unwarping = false;
     params.use_textline_orientation = false;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xenix-native"
-version = "1.3.2"
+version = "1.3.3"
 description = "Xenix native"
 authors = [{ name = "Lan_zhijiang", email = "lanzhijiang@foxmail.com" }]
 readme = "README.md"

--- a/scripts/build_knowledge_ocr_runtime.py
+++ b/scripts/build_knowledge_ocr_runtime.py
@@ -5,12 +5,14 @@ import hashlib
 import json
 import os
 import shutil
+import stat
 import struct
 import subprocess
 import tarfile
+import time
 import urllib.request
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, BinaryIO, Literal, Self, cast
 from uuid import uuid4
 from urllib.parse import urlparse
@@ -33,6 +35,9 @@ DEFAULT_OUTPUT_ROOT = ROOT / "dist" / "knowledge-ocr"
 MAX_PROTOCOL_MESSAGE_BYTES = 16 * 1024 * 1024
 ARCHIVE_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
 RUNTIME_DIRECTORY = "xenix-knowledge-ocr"
+PIPELINE_CONFIG_NAME = "OCR.yaml"
+RUNTIME_MANIFEST_NAME = "runtime.json"
+BINARY_SUFFIXES = frozenset({".dll", ".exe"})
 REQUIRED_DOWNLOADS = {
     "paddle_inference",
     "opencv",
@@ -386,6 +391,73 @@ def _source_tree(root: Path) -> Path:
     raise RuntimeError(f"Expected a source tree under {root}.")
 
 
+def _remove_tree(path: Path) -> None:
+    """Remove a generated tree, including Git's read-only pack indexes."""
+
+    def clear_readonly(function: Any, target: str, _exception: BaseException) -> None:
+        os.chmod(target, stat.S_IWRITE)
+        function(target)
+
+    shutil.rmtree(path, onexc=clear_readonly)
+
+
+def _opencv_root(stage: Path) -> Path | None:
+    configs = stage.rglob("OpenCVConfig.cmake")
+    config = next(
+        (
+            candidate
+            for candidate in configs
+            if candidate.as_posix().endswith("x64/vc16/lib/OpenCVConfig.cmake")
+        ),
+        None,
+    )
+    if config is None:
+        return None
+    root = config.parent.parent.parent.parent
+    required = (
+        config,
+        root / "x64/vc16/bin/opencv_world470.dll",
+        root / "x64/vc16/lib/opencv_world470.lib",
+    )
+    return root if all(path.is_file() for path in required) else None
+
+
+def _extract_opencv(archive: Path, destination: Path) -> Path:
+    """Extract the locked OpenCV self-extractor without waiting indefinitely."""
+
+    process = subprocess.Popen([str(archive), f"-o{destination}", "-y"])
+    ready_since: float | None = None
+    deadline = time.monotonic() + 120
+    try:
+        while True:
+            root = _opencv_root(destination)
+            returncode = process.poll()
+            if root is not None:
+                if returncode is not None:
+                    if returncode != 0:
+                        raise RuntimeError("Locked OpenCV self-extractor failed.")
+                    return root
+                if ready_since is None:
+                    ready_since = time.monotonic()
+                elif time.monotonic() - ready_since >= 2:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=10)
+                    return root
+            elif returncode is not None:
+                raise RuntimeError("Locked OpenCV self-extractor did not produce its SDK.")
+            if time.monotonic() >= deadline:
+                raise RuntimeError("Locked OpenCV self-extractor timed out.")
+            time.sleep(0.2)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=10)
+
+
 def _extract_inputs(
     downloads: dict[str, Path],
     work: Path,
@@ -405,11 +477,7 @@ def _extract_inputs(
 
     opencv_stage = extracted / "opencv"
     opencv_stage.mkdir()
-    _run([str(downloads["opencv"]), f"-o{opencv_stage}", "-y"])
-    opencv_root = next(
-        path.parent.parent.parent.parent
-        for path in opencv_stage.rglob("x64/vc16/lib/OpenCVConfig.cmake")
-    )
+    opencv_root = _extract_opencv(downloads["opencv"], opencv_stage)
 
     model_stage = extracted / "models"
     detection_stage = model_stage / "detection"
@@ -461,6 +529,7 @@ def _build_worker(
             "-A",
             toolchain.architecture,
             f"-DXENIX_PADDLEOCR_SOURCE={source}",
+            f"-DXENIX_BUILD_WORKSPACE={work}",
             f"-DPADDLE_LIB={paddle_root}",
             f"-DOPENCV_DIR={opencv_root}",
             "-DWITH_GPU=OFF",
@@ -551,6 +620,7 @@ def _stage_runtime(
     lock: KnowledgeOcrRuntimeLock,
     *,
     work: Path,
+    source: Path,
     worker: Path,
     paddle_root: Path,
     opencv_root: Path,
@@ -566,20 +636,20 @@ def _stage_runtime(
     build_root = work / "cmake"
     dependency_roots = [build_root, paddle_root, opencv_root]
     for name in lock.runtime_files:
-        source: Path | None
+        dependency_source: Path | None
         if name == "xenix-ocr.exe":
-            source = worker
+            dependency_source = worker
         elif name == "vcomp140.dll":
             _verify_vcomp(vcomp140, lock.toolchain)
-            source = vcomp140
+            dependency_source = vcomp140
         else:
-            source = next(
+            dependency_source = next(
                 (_find_unique(root, name) for root in dependency_roots if list(root.rglob(name))),
                 None,
             )
-            if source is None:
+            if dependency_source is None:
                 raise RuntimeError(f"Required native OCR dependency is missing: {name}")
-        shutil.copy2(source, runtime / name)
+        shutil.copy2(dependency_source, runtime / name)
 
     models = runtime / "models"
     shutil.copytree(detection_model, models / "PP-OCRv6_medium_det")
@@ -588,18 +658,16 @@ def _stage_runtime(
 
     licenses = runtime / "licenses"
     licenses.mkdir()
-    paddle_license = _find_unique(
-        work / "PaddleOCR", "LICENSE"
-    )
+    paddle_license = _find_unique(source, "LICENSE")
     shutil.copy2(paddle_license, licenses / "PaddleOCR-LICENSE.txt")
     shutil.copy2(paddle_license, licenses / "Paddle-Inference-LICENSE.txt")
     shutil.copy2(_find_unique(opencv_root, "LICENSE"), licenses / "OpenCV-LICENSE.txt")
     shutil.copy2(
-        _find_unique(work / "PaddleOCR" / "deploy" / "cpp_infer" / "third_party" / "abseil-cpp", "LICENSE"),
+        _find_unique(source / "deploy" / "cpp_infer" / "third_party" / "abseil-cpp", "LICENSE"),
         licenses / "Abseil-LICENSE.txt",
     )
     shutil.copy2(
-        _find_unique(work / "PaddleOCR" / "deploy" / "cpp_infer" / "third_party" / "nlohmann", "LICENSE.MIT"),
+        _find_unique(source / "deploy" / "cpp_infer" / "third_party" / "nlohmann", "LICENSE.MIT"),
         licenses / "nlohmann-json-LICENSE.txt",
     )
 
@@ -619,7 +687,7 @@ def _stage_runtime(
         },
         "files": files,
     }
-    (runtime / "runtime.json").write_text(
+    (runtime / RUNTIME_MANIFEST_NAME).write_text(
         json.dumps(manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
         + "\n",
         encoding="utf-8",
@@ -685,12 +753,12 @@ def _request(
     return response.get("result")
 
 
-def verify_runtime(runtime: Path, golden_image: Path) -> None:
+def verify_runtime(runtime: Path, golden_image: Path, *, cwd: Path) -> None:
     log = runtime / "build-verification.log"
     with log.open("wb") as stderr:
         process = subprocess.Popen(
             [str(runtime / "xenix-ocr.exe"), "--stdio"],
-            cwd=runtime,
+            cwd=cwd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=stderr,
@@ -772,6 +840,168 @@ def write_content_addressed_archive(
         temporary.unlink(missing_ok=True)
 
 
+def _verify_archive_members(archive: Path) -> None:
+    with zipfile.ZipFile(archive) as package:
+        members = package.infolist()
+        if not members:
+            raise RuntimeError("Knowledge OCR archive is empty.")
+        names: set[str] = set()
+        prefix = f"{RUNTIME_DIRECTORY}/"
+        for member in members:
+            name = member.filename
+            if (
+                not name
+                or name in names
+                or name.endswith("/")
+                or not name.startswith(prefix)
+            ):
+                raise RuntimeError("Knowledge OCR archive layout is invalid.")
+            names.add(name)
+            if PurePosixPath(name).name == PIPELINE_CONFIG_NAME:
+                raise RuntimeError(
+                    "Knowledge OCR archive must not contain a pipeline config."
+                )
+
+
+def _manifest_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise RuntimeError("Knowledge OCR runtime manifest has an invalid file path.")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise RuntimeError("Knowledge OCR runtime manifest has an invalid file path.")
+    return path.as_posix()
+
+
+def _verify_runtime_manifest(runtime: Path, lock: KnowledgeOcrRuntimeLock) -> None:
+    manifest_path = runtime / RUNTIME_MANIFEST_NAME
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Knowledge OCR runtime manifest is invalid.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Knowledge OCR runtime manifest is invalid.")
+    if (
+        payload.get("schema_version") != 1
+        or payload.get("protocol_version") != 2
+        or payload.get("protocol_version") != lock.protocol_version
+        or payload.get("runtime_id") != lock.runtime_id
+        or payload.get("model_pack_id") != lock.model_pack_id
+    ):
+        raise RuntimeError("Knowledge OCR runtime manifest identity is invalid.")
+    files = payload.get("files")
+    if not isinstance(files, list):
+        raise RuntimeError("Knowledge OCR runtime manifest is invalid.")
+
+    expected: set[str] = set()
+    for entry in files:
+        if not isinstance(entry, dict) or set(entry) != {"path", "bytes", "sha256"}:
+            raise RuntimeError("Knowledge OCR runtime manifest is invalid.")
+        relative = _manifest_path(entry["path"])
+        if relative == RUNTIME_MANIFEST_NAME or relative in expected:
+            raise RuntimeError("Knowledge OCR runtime manifest is invalid.")
+        size = entry["bytes"]
+        digest = entry["sha256"]
+        if type(size) is not int or size < 0 or not isinstance(digest, str):
+            raise RuntimeError("Knowledge OCR runtime manifest is invalid.")
+        target = runtime.joinpath(*PurePosixPath(relative).parts)
+        if (
+            not target.is_file()
+            or target.stat().st_size != size
+            or sha256_file(target) != digest
+        ):
+            raise RuntimeError("Knowledge OCR runtime manifest file verification failed.")
+        expected.add(relative)
+
+    actual = {
+        path.relative_to(runtime).as_posix()
+        for path in runtime.rglob("*")
+        if path.is_file() and path.name != RUNTIME_MANIFEST_NAME
+    }
+    if actual != expected:
+        raise RuntimeError("Knowledge OCR archive contains unmanifested files.")
+    if any(PurePosixPath(relative).name == PIPELINE_CONFIG_NAME for relative in actual):
+        raise RuntimeError("Knowledge OCR archive must not contain a pipeline config.")
+
+
+def _binary_contains(path: Path, pattern: bytes) -> bool:
+    overlap = max(0, len(pattern) - 1)
+    tail = b""
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            content = tail + chunk
+            if pattern in content:
+                return True
+            tail = content[-overlap:] if overlap else b""
+    return False
+
+
+def _verify_runtime_binary_provenance(
+    runtime: Path,
+    forbidden_fragments: tuple[str, ...],
+) -> None:
+    patterns: set[bytes] = set()
+    for fragment in forbidden_fragments:
+        if not fragment:
+            raise RuntimeError("Knowledge OCR binary provenance marker is invalid.")
+        try:
+            patterns.add(fragment.encode("ascii"))
+        except UnicodeEncodeError:
+            patterns.add(fragment.encode("utf-8"))
+        patterns.add(fragment.encode("utf-16le"))
+    binaries = sorted(
+        path
+        for path in runtime.rglob("*")
+        if path.is_file() and path.suffix.lower() in BINARY_SUFFIXES
+    )
+    if not binaries:
+        raise RuntimeError("Knowledge OCR runtime has no native binaries to verify.")
+    for binary in binaries:
+        if any(_binary_contains(binary, pattern) for pattern in patterns):
+            raise RuntimeError(
+                "Knowledge OCR runtime binary contains forbidden build provenance."
+            )
+
+
+def _source_provenance_markers(source: Path, build_nonce: str) -> tuple[str, ...]:
+    resolved = source.resolve()
+    return (build_nonce, str(resolved), resolved.as_posix())
+
+
+def verify_consumer_archive(
+    archive: Path,
+    golden_image: Path,
+    verification: Path,
+    lock: KnowledgeOcrRuntimeLock,
+    *,
+    unavailable_source: Path | None = None,
+    forbidden_binary_fragments: tuple[str, ...] = (),
+) -> None:
+    """Verify the release artifact from a source-free consumer topology."""
+
+    if unavailable_source is not None and unavailable_source.exists():
+        raise RuntimeError("Knowledge OCR builder source checkout is still available.")
+    shutil.rmtree(verification, ignore_errors=True)
+    try:
+        consumer = verification / "consumer"
+        foreign_cwd = verification / "foreign-cwd"
+        _verify_archive_members(archive)
+        _safe_extract_zip(archive, consumer)
+        runtime = consumer / RUNTIME_DIRECTORY
+        if not runtime.is_dir():
+            raise RuntimeError("Knowledge OCR archive layout is invalid.")
+        _verify_runtime_manifest(runtime, lock)
+        _verify_runtime_binary_provenance(runtime, forbidden_binary_fragments)
+        foreign_cwd.mkdir(parents=True)
+        (foreign_cwd / PIPELINE_CONFIG_NAME).write_text(
+            "invalid_pipeline_config: true\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        verify_runtime(runtime, golden_image, cwd=foreign_cwd)
+    finally:
+        shutil.rmtree(verification, ignore_errors=True)
+
+
 def write_catalog(
     lock: KnowledgeOcrRuntimeLock,
     archive: Path,
@@ -822,16 +1052,15 @@ def verify_output(args: argparse.Namespace) -> tuple[Path, Path]:
 
     golden = download_locked("golden_image", lock.downloads["golden_image"], cache)
     verification = args.work_dir.resolve() / "cached-output-verification"
-    shutil.rmtree(verification, ignore_errors=True)
-    try:
-        _safe_extract_zip(archive, verification)
-        runtime = verification / RUNTIME_DIRECTORY
-        if not runtime.is_dir():
-            raise RuntimeError("Cached Knowledge OCR archive layout is invalid.")
-        verify_runtime(runtime, golden)
-    finally:
-        shutil.rmtree(verification, ignore_errors=True)
+    verify_consumer_archive(archive, golden, verification, lock)
     return archive, catalog
+
+
+def _new_build_workspace(work: Path) -> tuple[Path, str]:
+    build_nonce = uuid4().hex
+    workspace = work / f"build-{build_nonce}"
+    workspace.mkdir()
+    return workspace, build_nonce
 
 
 def build(args: argparse.Namespace) -> tuple[Path, Path]:
@@ -845,11 +1074,12 @@ def build(args: argparse.Namespace) -> tuple[Path, Path]:
         name: download_locked(name, item, cache)
         for name, item in lock.downloads.items()
     }
-    source = _prepare_source(lock, work / "PaddleOCR")
-    paddle, opencv, detection, recognition = _extract_inputs(downloads, work, source)
+    workspace, build_nonce = _new_build_workspace(work)
+    source = _prepare_source(lock, workspace / "PaddleOCR")
+    paddle, opencv, detection, recognition = _extract_inputs(downloads, workspace, source)
     worker = _build_worker(
         lock,
-        work=work,
+        work=workspace,
         source=source,
         paddle_root=paddle,
         opencv_root=opencv,
@@ -857,7 +1087,8 @@ def build(args: argparse.Namespace) -> tuple[Path, Path]:
     vcomp = _resolve_vcomp(args.vcomp140, lock.toolchain)
     runtime = _stage_runtime(
         lock,
-        work=work,
+        work=workspace,
+        source=source,
         worker=worker,
         paddle_root=paddle,
         opencv_root=opencv,
@@ -865,11 +1096,19 @@ def build(args: argparse.Namespace) -> tuple[Path, Path]:
         recognition_model=recognition,
         vcomp140=vcomp,
     )
-    verify_runtime(runtime, downloads["golden_image"])
     archive = write_content_addressed_archive(
         runtime,
         output,
         runtime_id=lock.runtime_id,
+    )
+    _remove_tree(source)
+    verify_consumer_archive(
+        archive,
+        downloads["golden_image"],
+        work / f"consumer-verification-{build_nonce}",
+        lock,
+        unavailable_source=source,
+        forbidden_binary_fragments=_source_provenance_markers(source, build_nonce),
     )
     catalog = output / "runtime_catalog.json"
     write_catalog(lock, archive, catalog)

--- a/tasks/ocr-v1.3.2-runtime-diagnosis/packet.md
+++ b/tasks/ocr-v1.3.2-runtime-diagnosis/packet.md
@@ -1,0 +1,121 @@
+# Self-Contained Native OCR Runtime
+
+## Objective
+
+Replace the provisional external `OCR.yaml` repair with a self-contained
+`xenix-ocr.exe` whose fixed Xenix pipeline configuration is compiled into the
+worker, and prove that the released runtime neither reads build/source-tree
+resources nor exposes the real builder checkout path.
+
+## Guardrails
+
+- Keep the two Paddle inference model directories and their model-owned
+  `inference.yml` files external; only the Xenix-owned pipeline composition and
+  defaults move into the worker.
+- Express the embedded pipeline through PaddleOCR's supported
+  `PaddleXConfigVariant` map interface. Do not fork or reimplement inference
+  algorithms.
+- Preserve the pinned PaddleOCR commit, Paddle Inference/model inputs, runtime
+  and model-pack identities, runtime manifest schema 1, and native protocol 2
+  unless implementation evidence proves a contract change is unavoidable. Any
+  such change returns to an Impact Handshake before mutation.
+- The worker must not depend on process CWD, executable location, a companion
+  pipeline YAML, environment variables, repository layout, or the PaddleOCR
+  source checkout.
+- The embedded values must be traceable to the pinned upstream `OCR.yaml`;
+  Xenix-specific overrides must remain explicit and covered by behavioral proof.
+- Remove the provisional archive-owned `OCR.yaml`, relative-path initialization,
+  source-config rename verification, and their obsolete documentation/tests.
+- Sanitize third-party `__FILE__` expansion so released binaries contain no real
+  local or GitHub Actions checkout path in ASCII or UTF-16LE form. A deterministic
+  virtual source label is acceptable for diagnostics.
+- Preserve unrelated worktree changes. Do not modify installed application state,
+  active OCR generations, branches, commits, or published releases.
+- Do not expose imported document contents in diagnostic or verification output.
+
+## Verification
+
+- Focused tests prove the embedded map contains every pipeline key required by
+  PaddleOCR for Xenix's enabled detection/recognition topology and preserves the
+  intended thresholds, limits, batch sizes, model names, and disabled optional
+  sub-pipelines. Compare the effective flattened key/value map after Xenix
+  overrides, not the YAML file's textual representation.
+- A fresh native build produces an archive with no pipeline `OCR.yaml`; its
+  manifest and member hashes remain valid, and the archive contains only
+  `runtime.json` plus the worker, model, dependency, notice, and license assets
+  required at runtime.
+- Extract the fresh archive into an independent consumer directory, make the
+  entire builder PaddleOCR checkout unavailable, and launch the real worker with
+  a different empty CWD containing a deliberately invalid `OCR.yaml`.
+- In that isolated topology, the real worker must pass `version`, `initialize`,
+  `self_test`, and golden-image recognition, including the expected Chinese and
+  English evidence.
+- Scan every released runtime binary for the randomized builder-root nonce and
+  its absolute checkout path in both ASCII and UTF-16LE. Any hit blocks release.
+- Run cached-output verification and deployment installation from the same
+  consumer-isolated artifact, then pass the frozen-package OCR/import/retrieval
+  smoke path.
+- `pdm run pytest --direct <focused selectors>`, `pdm run check`,
+  `pdm run build-knowledge-ocr`, `pdm run build-knowledge-ocr --verify-output`,
+  `pdm run test`, `pdm run smoke`, `pdm run package`, and
+  `pdm run smoke-package` pass.
+
+## Current Truth
+
+- Installed v1.3.2 downloads and validates its catalog-selected OCR archive, then
+  fails native initialization with `knowledge_ocr_response_invalid`.
+- The published worker contains
+  `D:\a\Xenix\Xenix\build\knowledge-ocr\PaddleOCR\...\utility.cc`.
+  PaddleOCR's `Utility::GetDefaultConfig("OCR")` uses that compile-time
+  `__FILE__` value to derive a source-tree `OCR.yaml`, so the worker exits when
+  the GitHub checkout is absent on the end-user machine.
+- The older development generation succeeds only because its embedded local
+  repository path happens to exist on this machine. This is environmental
+  coupling, not v1.3.0/v1.3.2 recognition incompatibility.
+- `_OCRPipeline` always needs a `YamlConfig`, but PaddleOCR supports either a YAML
+  path or an `unordered_map<string, string>`. Therefore the external pipeline
+  YAML is an upstream convenience, not an inherent Xenix runtime requirement.
+- The pipeline YAML supplies orchestration and defaults such as `text_type`,
+  module topology, detection thresholds/limits, recognition batch size, and
+  optional preprocessing flags. Per-model `inference.yml` files describe model
+  inference and cannot replace those pipeline values.
+- The provisional repair copies `OCR.yaml` into the archive and passes the
+  relative string `"OCR.yaml"` from `main.cpp`. It passes current verification
+  only because both the builder and product session launch with the runtime
+  directory as CWD.
+- That provisional repair is rejected for release: it leaves a companion config
+  dependency, retains real `__FILE__` paths in the binary, hides only one source
+  config during verification, and does not prove operation from an arbitrary CWD
+  after the full source checkout is unavailable.
+- The approved direction is to compile the fixed Xenix pipeline map into the
+  worker, remove the external pipeline YAML entirely, eliminate the
+  `GetDefaultConfig("OCR")` runtime branch, sanitize real build paths, and make
+  consumer isolation plus raw-binary scanning release-blocking.
+- `xenix-ocr.exe` now supplies PaddleOCR's supported map variant with the 31
+  flattened values from the pinned upstream `OCR.yaml`. Existing Xenix overrides
+  still disable document orientation, document unwarping, and textline
+  orientation; model-owned `inference.yml` files remain package assets.
+- The reviewed pinned compatibility patch makes an accidental
+  `GetDefaultConfig()` call fail with `FailedPrecondition` instead of deriving a
+  path from `__FILE__`. MSVC maps the whole disposable workspace to a stable
+  virtual path under deterministic compilation, covering PaddleOCR and SDK
+  headers alike.
+- Runtime archives no longer contain `OCR.yaml`. The builder uses a randomized
+  workspace, handles the OpenCV self-extractor's non-exiting process, clears
+  Git's read-only generated pack indexes, deletes the full PaddleOCR checkout,
+  and only then validates a consumer-extracted archive from a foreign CWD with a
+  deliberately invalid `OCR.yaml`.
+- The rebuilt archive is
+  `xenix-knowledge-ocr-win-x64-paddle-inference-3.3.0-paddleocr-3.7.0-win-x64-5f661643218c1028e5dc111321ced3e14bc82a9ce9774a31ff60f9e753a5b5ae.zip`.
+  It has no pipeline YAML, retains `runtime.json`, and scans clean for its
+  randomized workspace nonce and real build-root path in every runtime EXE/DLL
+  in ASCII and UTF-16LE.
+- Focused tests (9), repository checks, a fresh native build, cached-output
+  verification, all 39 repository tests, development smoke, application
+  packaging, and frozen-package OCR/import/retrieval smoke pass.
+
+## Next Step
+
+The approved v1.3.3 release is being promoted through the repository release
+protocol. Existing installed v1.3.2 state remains untouched until its update is
+published through the canonical feed.

--- a/tasks/release-v1.3.2.md
+++ b/tasks/release-v1.3.2.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Implementing the content-addressed Knowledge OCR artifact correction before a new
-`develop -> main` promotion.
+Completed. v1.3.2 is publicly visible and verified from main promotion commit
+`8fbaedd5`.
 
 ## Objective
 
@@ -40,8 +40,20 @@ runtime object that has the same logical runtime ID but different build bytes.
   immutable object identity.
 - The embedded catalog already owns artifact name, byte count, and SHA-256; the
   client generation ID already incorporates the artifact SHA-256.
+- Commit `ef04625` was promoted through PR #116; Native CI run `30263030953`
+  passed in 5 minutes 17 seconds.
+- `v1.3.2` resolves to main promotion commit `8fbaedd5`; local and remote release
+  identity checks bound it to PR #116.
+- Native Release run `30263473671` passed in 1 hour 3 minutes 13 seconds,
+  including native OCR build/self-test and packaged smoke.
+- The published OCR archive is 205,199,980 bytes. Its name and catalog both carry
+  SHA-256 `3e76bae9cb17bbacac0174bcd3db80a6e10617afc2f9b98c913de7850b4b1322`.
+- Publisher time was 961.25 seconds and visibility/final verification was 447.39
+  seconds. The public OCR object returns HTTP 200, supports byte ranges, and
+  returns 206 for `bytes=0-0`; Setup returns 200 with `no-cache`.
+- The canonical stable feed now declares v1.3.2.
 
 ## Next Step
 
-Validate the producer and existing portfolio, then promote v1.3.2 through Native
-CI before creating its immutable tag.
+No release action remains. Retain the immutable tag, workflow evidence, manifest,
+runtime catalog, publication timing, and rollback-history key.

--- a/tasks/release-v1.3.3.md
+++ b/tasks/release-v1.3.3.md
@@ -1,0 +1,44 @@
+# v1.3.3 Release Packet
+
+## Objective
+
+Publish Xenix Native v1.3.3 with a self-contained native Knowledge OCR runtime,
+so a released worker never resolves its pipeline configuration from a build
+machine path, its current directory, or a companion `OCR.yaml` file.
+
+## Guardrails
+
+- Promote only the reviewed same-repository `develop -> main` result; do not
+  merge or push `main` locally.
+- The immutable `v1.3.3` tag must name that exact promotion merge commit and
+  declare project version `1.3.3`.
+- Leave unrelated local workflow, ignore-rule, task, and activation work out of
+  this release commit.
+- Publish only through the tag-triggered `Native Release` workflow; never
+  replace or remove an immutable object or a pushed tag.
+
+## Verification
+
+- Focused native-runtime tests, repository checks, smoke tests, package, and
+  packaged smoke pass before promotion.
+- Promotion Native CI passes on the `develop -> main` pull request.
+- Local release identity binds `v1.3.3` to the resulting `main` promotion
+  commit before the tag is pushed.
+- The tag-triggered Native Release workflow builds and verifies the isolated
+  OCR runtime, packages the application, and publishes the canonical feed.
+
+## Current Truth
+
+- v1.3.2's native worker can fail when PaddleOCR's default configuration
+  attempts to find source-tree `OCR.yaml` through a compile-time path.
+- v1.3.3 passes an explicit compiled-in PaddleX configuration, disables the
+  upstream default-config fallback, maps build paths deterministically, and
+  verifies the archive from a foreign working directory after removing the
+  builder checkout.
+- The candidate native archive is
+  `xenix-knowledge-ocr-win-x64-paddle-inference-3.3.0-paddleocr-3.7.0-win-x64-5f661643218c1028e5dc111321ced3e14bc82a9ce9774a31ff60f9e753a5b5ae.zip`.
+
+## Next Step
+
+Commit the bounded v1.3.3 candidate to `develop`, promote it to `main`, then
+create and push the immutable tag after the promotion gate passes.

--- a/tests/test_knowledge_ocr_runtime.py
+++ b/tests/test_knowledge_ocr_runtime.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import shutil
+import stat
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_knowledge_ocr_runtime.py"
+
+
+def _build_module():
+    name = "xenix_knowledge_ocr_build_for_test"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: Path, data: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+def _lock() -> SimpleNamespace:
+    return SimpleNamespace(
+        protocol_version=2,
+        runtime_id="runtime-id",
+        model_pack_id="model-pack-id",
+    )
+
+
+def _runtime(build, root: Path, *, worker: bytes = b"worker") -> Path:
+    runtime = root / build.RUNTIME_DIRECTORY
+    _write(runtime / "xenix-ocr.exe", worker)
+    _write(runtime / "dependency.dll", b"dependency")
+    _write(runtime / "models/detection/inference.yml", b"detection")
+    _write(runtime / "models/recognition/inference.yml", b"recognition")
+    manifest = {
+        "schema_version": 1,
+        "protocol_version": 2,
+        "runtime_id": "runtime-id",
+        "model_pack_id": "model-pack-id",
+        "files": [
+            build._file_entry(path, runtime)
+            for path in sorted(runtime.rglob("*"))
+            if path.is_file()
+        ],
+    }
+    (runtime / build.RUNTIME_MANIFEST_NAME).write_text(
+        json.dumps(manifest), encoding="utf-8", newline="\n"
+    )
+    return runtime
+
+
+def test_staged_runtime_excludes_pipeline_config_and_preserves_manifest_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    build = _build_module()
+    work = tmp_path / "work"
+    source = work / "PaddleOCR"
+    _write(source / "LICENSE", b"paddle license")
+    _write(
+        source / "deploy/cpp_infer/third_party/abseil-cpp/LICENSE",
+        b"abseil license",
+    )
+    _write(
+        source / "deploy/cpp_infer/third_party/nlohmann/LICENSE.MIT",
+        b"nlohmann license",
+    )
+    native_root = tmp_path / "native"
+    _write(native_root / "THIRD_PARTY_NOTICES.txt", b"notices")
+    monkeypatch.setattr(build, "NATIVE_ROOT", native_root)
+
+    worker = _write(tmp_path / "xenix-ocr.exe", b"worker")
+    vcomp = _write(tmp_path / "vcomp140.dll", b"vcomp")
+    paddle_root = tmp_path / "paddle"
+    _write(paddle_root / "dependency.dll", b"dependency")
+    opencv_root = tmp_path / "opencv"
+    _write(opencv_root / "LICENSE", b"opencv license")
+    detection_model = tmp_path / "detection"
+    recognition_model = tmp_path / "recognition"
+    _write(detection_model / "inference.yml", b"detection")
+    _write(recognition_model / "inference.yml", b"recognition")
+
+    lock = SimpleNamespace(
+        runtime_files=["xenix-ocr.exe", "vcomp140.dll", "dependency.dll"],
+        protocol_version=2,
+        runtime_id="runtime-id",
+        model_pack_id="model-pack-id",
+        toolchain=SimpleNamespace(
+            vcomp140_bytes=vcomp.stat().st_size,
+            vcomp140_sha256=hashlib.sha256(vcomp.read_bytes()).hexdigest(),
+        ),
+    )
+
+    runtime = build._stage_runtime(
+        lock,
+        work=work,
+        source=source,
+        worker=worker,
+        paddle_root=paddle_root,
+        opencv_root=opencv_root,
+        detection_model=detection_model,
+        recognition_model=recognition_model,
+        vcomp140=vcomp,
+    )
+
+    assert not (runtime / build.PIPELINE_CONFIG_NAME).exists()
+    manifest = json.loads(
+        (runtime / build.RUNTIME_MANIFEST_NAME).read_text(encoding="utf-8")
+    )
+    assert manifest["schema_version"] == 1
+    assert manifest["protocol_version"] == 2
+    assert build.PIPELINE_CONFIG_NAME not in {
+        entry["path"] for entry in manifest["files"]
+    }
+
+
+def test_consumer_archive_runs_from_foreign_cwd_after_source_removal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    build = _build_module()
+    runtime = _runtime(build, tmp_path / "stage")
+    archive = build.write_content_addressed_archive(
+        runtime,
+        tmp_path / "output",
+        runtime_id="runtime-id",
+    )
+    source = tmp_path / "builder" / "PaddleOCR"
+    source.mkdir(parents=True)
+    shutil.rmtree(source)
+    observed: list[tuple[Path, Path, Path]] = []
+
+    def verify(staged_runtime: Path, golden_image: Path, *, cwd: Path) -> None:
+        assert not source.exists()
+        assert cwd != staged_runtime
+        assert (cwd / build.PIPELINE_CONFIG_NAME).read_text(encoding="utf-8") == (
+            "invalid_pipeline_config: true\n"
+        )
+        observed.append((staged_runtime, golden_image, cwd))
+
+    monkeypatch.setattr(build, "verify_runtime", verify)
+    golden = tmp_path / "golden.png"
+    build.verify_consumer_archive(
+        archive,
+        golden,
+        tmp_path / "verification",
+        _lock(),
+        unavailable_source=source,
+    )
+
+    assert len(observed) == 1
+    staged_runtime, golden_image, cwd = observed[0]
+    assert staged_runtime != runtime
+    assert golden_image == golden
+    assert cwd.name == "foreign-cwd"
+
+
+def test_consumer_archive_rejects_pipeline_config_member(tmp_path: Path) -> None:
+    build = _build_module()
+    runtime = _runtime(build, tmp_path / "stage")
+    _write(runtime / build.PIPELINE_CONFIG_NAME, b"pipeline_name: OCR\n")
+    archive = build.write_content_addressed_archive(
+        runtime,
+        tmp_path / "output",
+        runtime_id="runtime-id",
+    )
+
+    with pytest.raises(RuntimeError, match="must not contain a pipeline config"):
+        build.verify_consumer_archive(
+            archive,
+            tmp_path / "golden.png",
+            tmp_path / "verification",
+            _lock(),
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"builder-nonce-123",
+        "builder-nonce-123".encode("utf-16le"),
+    ],
+    ids=["ascii", "utf-16le"],
+)
+def test_binary_provenance_scan_rejects_build_markers(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    build = _build_module()
+    runtime = tmp_path / build.RUNTIME_DIRECTORY
+    _write(runtime / "xenix-ocr.exe", b"prefix" + payload + b"suffix")
+
+    with pytest.raises(RuntimeError, match="forbidden build provenance"):
+        build._verify_runtime_binary_provenance(runtime, ("builder-nonce-123",))
+
+
+class _OpenCvProcess:
+    def __init__(self, returncode: int | None) -> None:
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = -15
+
+    def wait(self, *, timeout: float) -> int | None:
+        del timeout
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+
+def test_opencv_root_requires_the_build_sdk_members(tmp_path: Path) -> None:
+    build = _build_module()
+    stage = tmp_path / "stage"
+    root = stage / "opencv" / "build"
+    _write(root / "x64/vc16/lib/OpenCVConfig.cmake", b"config")
+    _write(root / "x64/vc16/lib/opencv_world470.lib", b"library")
+    _write(root / "x64/vc16/bin/opencv_world470.dll", b"dll")
+
+    assert build._opencv_root(stage) == root
+
+
+def test_remove_tree_clears_a_generated_read_only_file(tmp_path: Path) -> None:
+    build = _build_module()
+    generated = tmp_path / "PaddleOCR"
+    locked = _write(generated / ".git/objects/pack/locked.idx", b"index")
+    locked.chmod(stat.S_IREAD)
+
+    build._remove_tree(generated)
+
+    assert not generated.exists()
+
+
+def test_opencv_extractor_accepts_a_normally_completed_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    build = _build_module()
+    process = _OpenCvProcess(returncode=0)
+    root = tmp_path / "opencv-sdk"
+    monkeypatch.setattr(build.subprocess, "Popen", lambda _command: process)
+    monkeypatch.setattr(build, "_opencv_root", lambda _stage: root)
+
+    assert build._extract_opencv(tmp_path / "opencv.exe", tmp_path / "stage") == root
+    assert not process.terminated
+    assert not process.killed
+
+
+def test_opencv_extractor_stops_a_completed_but_nonexiting_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    build = _build_module()
+    process = _OpenCvProcess(returncode=None)
+    root = tmp_path / "opencv-sdk"
+    timestamps = iter((0.0, 0.0, 1.0, 2.0))
+    monkeypatch.setattr(build.subprocess, "Popen", lambda _command: process)
+    monkeypatch.setattr(build, "_opencv_root", lambda _stage: root)
+    monkeypatch.setattr(build.time, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(build.time, "sleep", lambda _seconds: None)
+
+    assert build._extract_opencv(tmp_path / "opencv.exe", tmp_path / "stage") == root
+    assert process.terminated
+    assert not process.killed


### PR DESCRIPTION
## What changed

- Makes the native Knowledge OCR worker self-contained by compiling the fixed PaddleX pipeline configuration into `xenix-ocr.exe`.
- Removes the released worker's dependency on a source-tree or companion `OCR.yaml` and sanitizes real build paths from release binaries.
- Adds consumer-isolated runtime validation, including foreign-CWD execution, source-checkout removal, and binary path scans.

## Why

v1.3.2 can initialize a valid downloaded OCR archive and then fail because PaddleOCR derives a build-machine `OCR.yaml` path from `__FILE__`. The old development runtime only worked accidentally where that local source path existed.

## Impact

Local OCR setup in v1.3.3 downloads a content-addressed runtime that initializes independently of the builder checkout and its current working directory. Model-owned inference metadata and native protocol compatibility remain unchanged.

## Validation

- Focused native runtime tests: 9 passed
- `pdm run check`
- Fresh native runtime build and `--verify-output`
- `pdm run test`, `pdm run smoke`, `pdm run package`, and `pdm run smoke-package`